### PR TITLE
chore: bump @fairmint/open-captable-protocol-daml-js to 0.2.160

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@apidevtools/json-schema-ref-parser": "15.3.5",
     "@eslint/eslintrc": "3.3.5",
     "@fairmint/canton-node-sdk": "0.0.197",
-    "@fairmint/open-captable-protocol-daml-js": "0.2.159",
+    "@fairmint/open-captable-protocol-daml-js": "0.2.160",
     "@types/jest": "30.0.0",
     "@types/jsonwebtoken": "9.0.10",
     "@types/node": "25.5.2",
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@fairmint/canton-node-sdk": ">=0.0.195 <0.1.0",
-    "@fairmint/open-captable-protocol-daml-js": ">=0.2.159 <0.3.0"
+    "@fairmint/open-captable-protocol-daml-js": ">=0.2.160 <0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/ci/assert-min-open-captable-daml-js.mjs
+++ b/scripts/ci/assert-min-open-captable-daml-js.mjs
@@ -10,8 +10,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const MIN_EXACT_DEV = '0.2.159';
-const MIN_PEER_PREFIX = '>=0.2.159';
+const MIN_EXACT_DEV = '0.2.160';
+const MIN_PEER_PREFIX = '>=0.2.160';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));


### PR DESCRIPTION
Bumps the DAML JS bindings devDependency and peer floor to **0.2.160** (published from [open-captable-protocol-daml#212](https://github.com/Fairmint/open-captable-protocol-daml/pull/212)). Updates the CI assert script to match.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-floor bump that only changes the required/validated version of `@fairmint/open-captable-protocol-daml-js`. Main risk is downstream incompatibility if consumers rely on the previous minimum version.
> 
> **Overview**
> Updates the SDK to require `@fairmint/open-captable-protocol-daml-js` `0.2.160` by bumping the devDependency and raising the peer dependency floor.
> 
> Aligns the CI guard script (`scripts/ci/assert-min-open-captable-daml-js.mjs`) to enforce the new minimum version for both dev and peer dependency ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bee5d5064657ab8addfda23783d41d76956ca42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@fairmint/open-captable-protocol-daml-js` dependency to version 0.2.160 and corresponding build verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->