### PR TITLE
fix(cap-table): validate discovery via packageName and module path

### DIFF
--- a/src/functions/OpenCapTable/capTable/getCapTableState.ts
+++ b/src/functions/OpenCapTable/capTable/getCapTableState.ts
@@ -419,11 +419,7 @@ function requirePinnedCapTableCreatedEvent(createdEvent: {
   packageName?: unknown;
 }): string {
   const templateId = requireCapTableTemplateIdString(createdEvent.templateId, createdEvent.contractId);
-  const packageName = requireCapTablePackageNameString(
-    createdEvent.packageName,
-    createdEvent.contractId,
-    templateId
-  );
+  const packageName = requireCapTablePackageNameString(createdEvent.packageName, createdEvent.contractId, templateId);
 
   if (packageName !== PINNED_CAP_TABLE_PACKAGE_LINE.packageName) {
     throw new OcpContractError('CapTable contract packageName does not match pinned OpenCapTable package line', {

--- a/src/functions/OpenCapTable/capTable/getCapTableState.ts
+++ b/src/functions/OpenCapTable/capTable/getCapTableState.ts
@@ -382,14 +382,27 @@ function damlTemplateModuleEntityPath(templateId: string, contractId: string): s
       templateId,
     });
   }
-  return templateId.slice(i + 1);
+  const path = templateId.slice(i + 1);
+  if (path.length === 0) {
+    throw new OcpContractError('CapTable contract templateId is missing module path after package reference', {
+      code: OcpErrorCodes.SCHEMA_MISMATCH,
+      contractId,
+      templateId,
+    });
+  }
+  return path;
 }
 
-function requireCapTablePackageNameString(packageName: unknown, contractId: string): string {
+function requireCapTablePackageNameString(
+  packageName: unknown,
+  contractId: string,
+  templateIdForDiagnostics?: string
+): string {
   if (typeof packageName !== 'string' || packageName.length === 0) {
     throw new OcpContractError('CapTable contract packageName must be a non-empty string', {
       code: OcpErrorCodes.SCHEMA_MISMATCH,
       contractId,
+      ...(templateIdForDiagnostics ? { templateId: templateIdForDiagnostics } : {}),
     });
   }
   return packageName;
@@ -406,7 +419,11 @@ function requirePinnedCapTableCreatedEvent(createdEvent: {
   packageName?: unknown;
 }): string {
   const templateId = requireCapTableTemplateIdString(createdEvent.templateId, createdEvent.contractId);
-  const packageName = requireCapTablePackageNameString(createdEvent.packageName, createdEvent.contractId);
+  const packageName = requireCapTablePackageNameString(
+    createdEvent.packageName,
+    createdEvent.contractId,
+    templateId
+  );
 
   if (packageName !== PINNED_CAP_TABLE_PACKAGE_LINE.packageName) {
     throw new OcpContractError('CapTable contract packageName does not match pinned OpenCapTable package line', {
@@ -450,7 +467,7 @@ async function capTableWithArchiveContext(
   return { ...base, templateId, systemOperatorPartyId };
 }
 
-/** Active CapTable contracts for the issuer on the current template only. */
+/** Active CapTable contracts for the issuer on the current pinned package line only. */
 async function loadCurrentCapTables(
   client: LedgerJsonApiClient,
   issuerPartyId: string

--- a/src/functions/OpenCapTable/capTable/getCapTableState.ts
+++ b/src/functions/OpenCapTable/capTable/getCapTableState.ts
@@ -1,18 +1,24 @@
 /**
- * Query Canton for the state of a CapTable on **this SDK’s pinned template** (`OCP_TEMPLATES.capTable`).
+ * Query Canton for the state of a CapTable on **this SDK’s pinned OpenCapTable package line** (`OCP_TEMPLATES.capTable`).
+ *
+ * Requests use the package-name symbolic template id (`#OpenCapTable-vN:…`). The ledger may echo
+ * `createdEvent.templateId` using either that form or the package-id (`hash:…`) form for the same template.
+ *
+ * Validation therefore uses **structured fields** from the Canton JSON API: `createdEvent.packageName` must match
+ * the pinned package name parsed from `OCP_TEMPLATES.capTable`, and the **module + entity** suffix of
+ * `createdEvent.templateId` (everything after the first `:`) must match the pinned template. The SDK returns the
+ * raw ledger `templateId` string unchanged for downstream commands.
  *
  * This is **not** a global “does this issuer have any CapTable on any package line?” API. Ledger filters use
- * that template id; contracts on other OpenCapTable package versions are outside this query and are neither
+ * the pinned template id; contracts on other OpenCapTable package versions are outside this query and are neither
  * loaded nor classified here.
  *
  * `classifyIssuerCapTables` / `getCapTableState` therefore answer only: “is there an active CapTable **on the
- * current template** for this issuer?” A `none` / `null` result means the filtered query returned no matching row,
+ * current package line** for this issuer?” A `none` / `null` result means the filtered query returned no matching row,
  * not that the issuer has zero CapTable-shaped contracts in Canton overall. Whether it is safe to create a new
  * CapTable is a separate DAML / operations concern.
  *
- * Any row returned for the filtered query must carry a non-empty `createdEvent.templateId` that **exactly**
- * matches `OCP_TEMPLATES.capTable`; otherwise the SDK throws `SCHEMA_MISMATCH` (including when the participant
- * returns an unexpected template id for the same filter).
+ * Rows that fail package-name or module-path checks throw `SCHEMA_MISMATCH`.
  *
  * @module getCapTableState
  */
@@ -25,8 +31,27 @@ import { OcpContractError, OcpErrorCodes } from '../../../errors';
 import { parseDamlMap } from '../../../utils/typeConversions';
 import type { OcfEntityType } from './batchTypes';
 
-/** CapTable template ID this SDK treats as current. */
+/** CapTable template ID this SDK treats as current (package-name symbolic form; used for ledger queries). */
 const CURRENT_CAP_TABLE_TEMPLATE_ID = OCP_TEMPLATES.capTable;
+
+/**
+ * Pinned package line + module path from {@link CURRENT_CAP_TABLE_TEMPLATE_ID} (`#PackageName:Module:Entity`).
+ * Used to validate `getActiveContracts` rows without requiring `createdEvent.templateId` to match the full string.
+ */
+const PINNED_CAP_TABLE_PACKAGE_LINE = (() => {
+  const full = CURRENT_CAP_TABLE_TEMPLATE_ID;
+  if (!full.startsWith('#')) {
+    throw new Error(`Invalid pinned CapTable template id (expected # prefix): ${full}`);
+  }
+  const withoutHash = full.slice(1);
+  const firstColon = withoutHash.indexOf(':');
+  if (firstColon < 0) {
+    throw new Error(`Invalid pinned CapTable template id (expected :): ${full}`);
+  }
+  const packageName = withoutHash.slice(0, firstColon);
+  const moduleEntityPath = withoutHash.slice(firstColon + 1);
+  return { packageName, moduleEntityPath };
+})();
 
 /**
  * Type guard to check if a contract entry is a JsActiveContract with complete structure.
@@ -228,14 +253,14 @@ export interface CapTableWithArchiveContext extends CapTableState {
 }
 
 /**
- * CapTable presence **for the pinned template only** (`OCP_TEMPLATES.capTable`).
+ * CapTable presence **for the pinned package line only** (see module doc; query uses `OCP_TEMPLATES.capTable`).
  * `none` means the filtered ledger query found no row on that template, not “no CapTable exists on any package.”
  */
 export type IssuerCapTableStatus = 'current' | 'none';
 
 export interface IssuerCapTableClassification {
   status: IssuerCapTableStatus;
-  /** Populated when `status` is `current` (exactly one CapTable on the pinned template). */
+  /** Populated when `status` is `current` (exactly one CapTable on the pinned package line). */
   current: CapTableWithArchiveContext | null;
 }
 
@@ -347,16 +372,60 @@ function requireCapTableTemplateIdString(templateId: unknown, contractId: string
   return templateId;
 }
 
-function requireCurrentCapTableTemplateId(templateId: unknown, contractId: string): string {
-  const currentTemplateId = requireCapTableTemplateIdString(templateId, contractId);
-  if (currentTemplateId !== CURRENT_CAP_TABLE_TEMPLATE_ID) {
-    throw new OcpContractError('CapTable contract templateId did not match requested template scope', {
+/** Module + entity path after the package reference (first `:`), for `#pkg:Mod:Ent` or `hash:Mod:Ent`. */
+function damlTemplateModuleEntityPath(templateId: string, contractId: string): string {
+  const i = templateId.indexOf(':');
+  if (i < 0) {
+    throw new OcpContractError('CapTable contract templateId is missing package or module path', {
       code: OcpErrorCodes.SCHEMA_MISMATCH,
       contractId,
-      templateId: currentTemplateId,
+      templateId,
     });
   }
-  return currentTemplateId;
+  return templateId.slice(i + 1);
+}
+
+function requireCapTablePackageNameString(packageName: unknown, contractId: string): string {
+  if (typeof packageName !== 'string' || packageName.length === 0) {
+    throw new OcpContractError('CapTable contract packageName must be a non-empty string', {
+      code: OcpErrorCodes.SCHEMA_MISMATCH,
+      contractId,
+    });
+  }
+  return packageName;
+}
+
+/**
+ * Ensures the created event is the pinned CapTable template (same package line + module path as
+ * `OCP_TEMPLATES.capTable`), regardless of whether `templateId` uses package-name or package-id form.
+ * @returns Raw ledger `templateId` for downstream use.
+ */
+function requirePinnedCapTableCreatedEvent(createdEvent: {
+  contractId: string;
+  templateId?: unknown;
+  packageName?: unknown;
+}): string {
+  const templateId = requireCapTableTemplateIdString(createdEvent.templateId, createdEvent.contractId);
+  const packageName = requireCapTablePackageNameString(createdEvent.packageName, createdEvent.contractId);
+
+  if (packageName !== PINNED_CAP_TABLE_PACKAGE_LINE.packageName) {
+    throw new OcpContractError('CapTable contract packageName does not match pinned OpenCapTable package line', {
+      code: OcpErrorCodes.SCHEMA_MISMATCH,
+      contractId: createdEvent.contractId,
+      templateId,
+    });
+  }
+
+  const moduleEntityPath = damlTemplateModuleEntityPath(templateId, createdEvent.contractId);
+  if (moduleEntityPath !== PINNED_CAP_TABLE_PACKAGE_LINE.moduleEntityPath) {
+    throw new OcpContractError('CapTable contract template module path does not match pinned CapTable template', {
+      code: OcpErrorCodes.SCHEMA_MISMATCH,
+      contractId: createdEvent.contractId,
+      templateId,
+    });
+  }
+
+  return templateId;
 }
 
 async function capTableWithArchiveContext(
@@ -399,7 +468,7 @@ async function loadCurrentCapTables(
       });
     }
     const { createdEvent } = contract.contractEntry.JsActiveContract;
-    const templateId = requireCurrentCapTableTemplateId(createdEvent.templateId, createdEvent.contractId);
+    const templateId = requirePinnedCapTableCreatedEvent(createdEvent);
     out.push(await capTableWithArchiveContext(client, createdEvent, templateId));
   }
   if (out.length > 1) {
@@ -412,7 +481,7 @@ async function loadCurrentCapTables(
 }
 
 /**
- * Classifies whether the issuer has an active CapTable **on the pinned template** (see module doc).
+ * Classifies whether the issuer has an active CapTable **on the pinned package line** (see module doc).
  * Other package lines are out of scope and do not affect `status`.
  */
 export async function classifyIssuerCapTables(
@@ -427,7 +496,7 @@ export async function classifyIssuerCapTables(
 }
 
 /**
- * Reads CapTable state **on the pinned template only**, or `null` if the filtered query finds no such contract.
+ * Reads CapTable state **on the pinned package line only**, or `null` if the filtered query finds no such contract.
  * This does not imply the issuer has no CapTable on other templates.
  */
 export async function getCapTableState(

--- a/test/capTable/getCapTableState.test.ts
+++ b/test/capTable/getCapTableState.test.ts
@@ -28,7 +28,10 @@ function isCurrentTemplateQuery(templateIds: string[] | undefined): boolean {
   return templateIds?.length === 1 && templateIds[0] === CURRENT_CAP_TABLE_TEMPLATE_ID;
 }
 
-/** `classifyIssuerCapTables` / `getCapTableState` query only the SDK’s current CapTable package line. */
+/**
+ * Test mock: `getActiveContracts` must be called with `templateIds: [OCP_TEMPLATES.capTable]` (package-name symbolic
+ * id). The SDK validates each returned row using `packageName` plus the module/entity suffix of `templateId`.
+ */
 function mockActiveContractsForCapTableState(
   mockClient: jest.Mocked<Pick<LedgerJsonApiClient, 'getActiveContracts'>>,
   responses: { current?: unknown[] }
@@ -333,6 +336,29 @@ describe('getCapTableState', () => {
       expect(result!.capTableContractId).toBe('cap-table-hash-id');
     });
 
+    it('should reject templateId with empty module path after package reference', async () => {
+      const badTemplateId = `${HASH_FORM_CAP_TABLE_TEMPLATE_ID.split(':')[0]}:`;
+      mockActiveContractsForCapTableState(mockClient, {
+        current: [
+          buildMockCapTableContract({
+            contractId: 'cap-table-bad-suffix',
+            issuerContractId: 'issuer-contract-456',
+            packageName: CURRENT_OCP_PACKAGE_NAME,
+            templateId: badTemplateId,
+            createArgument: { stakeholders: [['s', 'c']] },
+          }),
+        ],
+      });
+
+      await expect(getCapTableState(mockClient, 'issuer::party-123')).rejects.toMatchObject({
+        code: OcpErrorCodes.SCHEMA_MISMATCH,
+        contractId: 'cap-table-bad-suffix',
+        message: 'CapTable contract templateId is missing module path after package reference',
+        templateId: badTemplateId,
+      });
+      expect(mockClient.getEventsByContractId).not.toHaveBeenCalled();
+    });
+
     it.each([
       ['missing', undefined],
       ['empty', ''],
@@ -357,6 +383,7 @@ describe('getCapTableState', () => {
         code: OcpErrorCodes.SCHEMA_MISMATCH,
         contractId: 'cap-table-bad-pkg',
         message: 'CapTable contract packageName must be a non-empty string',
+        templateId: CURRENT_CAP_TABLE_TEMPLATE_ID,
       });
       expect(mockClient.getEventsByContractId).not.toHaveBeenCalled();
     });

--- a/test/capTable/getCapTableState.test.ts
+++ b/test/capTable/getCapTableState.test.ts
@@ -8,6 +8,7 @@
 
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
 import { OCP_TEMPLATES } from '@fairmint/open-captable-protocol-daml-js';
+import { CapTable } from '@fairmint/open-captable-protocol-daml-js/lib/Fairmint/OpenCapTable/CapTable/module';
 import { OcpErrorCodes } from '../../src/errors';
 import { classifyIssuerCapTables, getCapTableState } from '../../src/functions/OpenCapTable/capTable';
 
@@ -20,11 +21,14 @@ const NON_CURRENT_CAP_TABLE_TEMPLATE_ID = '#OpenCapTable-other:Fairmint.OpenCapT
 const CURRENT_OCP_PACKAGE_NAME = CURRENT_CAP_TABLE_TEMPLATE_ID.replace(/^#/, '').split(':')[0];
 const NON_CURRENT_CAP_TABLE_PACKAGE_NAME = 'OpenCapTable-other';
 
+/** Package-id form of the pinned CapTable template (same build as `OCP_TEMPLATES.capTable`). */
+const HASH_FORM_CAP_TABLE_TEMPLATE_ID = CapTable.templateIdWithPackageId;
+
 function isCurrentTemplateQuery(templateIds: string[] | undefined): boolean {
   return templateIds?.length === 1 && templateIds[0] === CURRENT_CAP_TABLE_TEMPLATE_ID;
 }
 
-/** `classifyIssuerCapTables` / `getCapTableState` query only the SDK’s current CapTable template. */
+/** `classifyIssuerCapTables` / `getCapTableState` query only the SDK’s current CapTable package line. */
 function mockActiveContractsForCapTableState(
   mockClient: jest.Mocked<Pick<LedgerJsonApiClient, 'getActiveContracts'>>,
   responses: { current?: unknown[] }
@@ -268,7 +272,7 @@ describe('getCapTableState', () => {
       expect(mockClient.getEventsByContractId).not.toHaveBeenCalled();
     });
 
-    it('should reject returned rows whose templateId does not match the requested current template', async () => {
+    it('should reject returned rows whose package line does not match the pinned OpenCapTable package', async () => {
       mockActiveContractsForCapTableState(mockClient, {
         current: [
           buildMockCapTableContract({
@@ -294,8 +298,88 @@ describe('getCapTableState', () => {
       await expect(getCapTableState(mockClient, 'issuer::party-123')).rejects.toMatchObject({
         code: OcpErrorCodes.SCHEMA_MISMATCH,
         contractId: 'cap-table-other',
-        message: 'CapTable contract templateId did not match requested template scope',
+        message: 'CapTable contract packageName does not match pinned OpenCapTable package line',
         templateId: NON_CURRENT_CAP_TABLE_TEMPLATE_ID,
+      });
+      expect(mockClient.getEventsByContractId).not.toHaveBeenCalled();
+    });
+
+    it('should accept hash-form templateId when packageName and module path match the pinned template', async () => {
+      const mockCapTableResponse = [
+        buildMockCapTableContract({
+          contractId: 'cap-table-hash-id',
+          issuerContractId: 'issuer-contract-456',
+          packageName: CURRENT_OCP_PACKAGE_NAME,
+          templateId: HASH_FORM_CAP_TABLE_TEMPLATE_ID,
+          createArgument: {
+            stakeholders: [['stakeholder-1', 'stakeholder-contract-1']],
+          },
+        }),
+      ];
+
+      mockActiveContractsForCapTableState(mockClient, { current: mockCapTableResponse });
+      mockClient.getEventsByContractId.mockResolvedValue(
+        buildMockIssuerEventsResponse('issuer-contract-456', {
+          id: 'issuer-ocf-hash',
+          legal_name: 'Hash Id Corp',
+          country_of_formation: 'US',
+          formation_date: '2024-01-01T00:00:00Z',
+        }) as never
+      );
+
+      const result = await getCapTableState(mockClient, 'issuer::party-123');
+
+      expect(result).not.toBeNull();
+      expect(result!.capTableContractId).toBe('cap-table-hash-id');
+    });
+
+    it.each([
+      ['missing', undefined],
+      ['empty', ''],
+    ])('should reject returned CapTable rows with a %s packageName', async (_case, packageName) => {
+      const row = buildMockCapTableContract({
+        contractId: 'cap-table-bad-pkg',
+        issuerContractId: 'issuer-contract-456',
+        packageName: CURRENT_OCP_PACKAGE_NAME,
+        createArgument: { stakeholders: [['s', 'c']] },
+      });
+      const ce = { ...row.contractEntry.JsActiveContract.createdEvent };
+      if (packageName === undefined) {
+        delete (ce as { packageName?: string }).packageName;
+      } else {
+        (ce as { packageName: string }).packageName = packageName;
+      }
+      mockActiveContractsForCapTableState(mockClient, {
+        current: [{ contractEntry: { JsActiveContract: { ...row.contractEntry.JsActiveContract, createdEvent: ce } } }],
+      });
+
+      await expect(getCapTableState(mockClient, 'issuer::party-123')).rejects.toMatchObject({
+        code: OcpErrorCodes.SCHEMA_MISMATCH,
+        contractId: 'cap-table-bad-pkg',
+        message: 'CapTable contract packageName must be a non-empty string',
+      });
+      expect(mockClient.getEventsByContractId).not.toHaveBeenCalled();
+    });
+
+    it('should reject when packageName matches but template module path does not', async () => {
+      const wrongEntityTemplateId = `#${CURRENT_OCP_PACKAGE_NAME}:Fairmint.OpenCapTable.CapTable:NotCapTable`;
+      mockActiveContractsForCapTableState(mockClient, {
+        current: [
+          buildMockCapTableContract({
+            contractId: 'cap-table-wrong-entity',
+            issuerContractId: 'issuer-contract-456',
+            packageName: CURRENT_OCP_PACKAGE_NAME,
+            templateId: wrongEntityTemplateId,
+            createArgument: { stakeholders: [['s', 'c']] },
+          }),
+        ],
+      });
+
+      await expect(getCapTableState(mockClient, 'issuer::party-123')).rejects.toMatchObject({
+        code: OcpErrorCodes.SCHEMA_MISMATCH,
+        contractId: 'cap-table-wrong-entity',
+        message: 'CapTable contract template module path does not match pinned CapTable template',
+        templateId: wrongEntityTemplateId,
       });
       expect(mockClient.getEventsByContractId).not.toHaveBeenCalled();
     });
@@ -734,7 +818,37 @@ describe('getCapTableState', () => {
       });
     });
 
-    it('should reject a returned row whose templateId does not match the requested current template', async () => {
+    it('should classify as current when templateId is package-id form but packageName matches pinned line', async () => {
+      mockActiveContractsForCapTableState(mockClient, {
+        current: [
+          buildMockCapTableContract({
+            contractId: 'cap-table-pkg-id',
+            issuerContractId: 'issuer-contract-456',
+            packageName: CURRENT_OCP_PACKAGE_NAME,
+            templateId: HASH_FORM_CAP_TABLE_TEMPLATE_ID,
+            createArgument: {
+              stakeholders: [['stakeholder-1', 'stakeholder-contract-1']],
+            },
+          }),
+        ],
+      });
+      mockClient.getEventsByContractId.mockResolvedValue(
+        buildMockIssuerEventsResponse('issuer-contract-456', {
+          id: 'issuer-ocf-id-123',
+          legal_name: 'Target Corp',
+          country_of_formation: 'US',
+          formation_date: '2024-01-01T00:00:00Z',
+        }) as never
+      );
+
+      const result = await classifyIssuerCapTables(mockClient, 'issuer::party-123');
+
+      expect(result.status).toBe('current');
+      expect(result.current?.capTableContractId).toBe('cap-table-pkg-id');
+      expect(result.current?.templateId).toBe(HASH_FORM_CAP_TABLE_TEMPLATE_ID);
+    });
+
+    it('should reject a returned row whose package line does not match the pinned OpenCapTable package', async () => {
       mockActiveContractsForCapTableState(mockClient, {
         current: [
           buildMockCapTableContract({
@@ -754,7 +868,7 @@ describe('getCapTableState', () => {
       await expect(classifyIssuerCapTables(mockClient, 'issuer::party-123')).rejects.toMatchObject({
         code: OcpErrorCodes.SCHEMA_MISMATCH,
         contractId: 'cap-table-other',
-        message: 'CapTable contract templateId did not match requested template scope',
+        message: 'CapTable contract packageName does not match pinned OpenCapTable package line',
         templateId: NON_CURRENT_CAP_TABLE_TEMPLATE_ID,
       });
       expect(mockClient.getEventsByContractId).not.toHaveBeenCalled();
@@ -773,7 +887,7 @@ describe('getCapTableState', () => {
       });
     });
 
-    it('should reject when a mismatched template row is returned', async () => {
+    it('should reject when a mismatched package line row is returned', async () => {
       mockActiveContractsForCapTableState(mockClient, {
         current: [
           buildMockCapTableContract({
@@ -788,7 +902,7 @@ describe('getCapTableState', () => {
       await expect(classifyIssuerCapTables(mockClient, 'issuer::party-123')).rejects.toMatchObject({
         code: OcpErrorCodes.SCHEMA_MISMATCH,
         contractId: 'cap-table-other',
-        message: 'CapTable contract templateId did not match requested template scope',
+        message: 'CapTable contract packageName does not match pinned OpenCapTable package line',
         templateId: NON_CURRENT_CAP_TABLE_TEMPLATE_ID,
       });
       expect(mockClient.getEventsByContractId).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
Replication and other callers failed with `SCHEMA_MISMATCH` when Canton returned `createdEvent.templateId` in package-id (`hash:…`) form while the SDK compared the full string to the package-name symbolic id from `OCP_TEMPLATES.capTable`.

## Change
- Keep `getActiveContracts` queries on the package-name template id.
- Validate responses using Canton’s structured `createdEvent.packageName` plus the module/entity suffix of `templateId` (everything after the first `:`), so both symbolic and hash-prefixed `templateId` strings match when they refer to the same pinned CapTable.
- Return the raw ledger `templateId` unchanged for downstream commands.

## Tests
- Regression coverage for hash-form `templateId`, missing/empty `packageName`, wrong package line, and wrong module/entity suffix.

## Follow-up
After this ships in a new `@open-captable-protocol/canton` release, bump the dependency in `canton` (companion doc PR can align comments in `capTableVerification` / `deployCapTables` if not merged separately).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes contract-discovery validation logic for CapTable lookups; mis-validation could cause false negatives/positives when selecting a CapTable contract. Risk is mitigated by expanded unit test coverage across hash/symbolic template IDs and schema edge cases.
> 
> **Overview**
> Fixes `getCapTableState` / `classifyIssuerCapTables` to handle Canton returning `createdEvent.templateId` in either package-name (`#OpenCapTable-vN:…`) or package-id (`hash:…`) form.
> 
> The SDK still queries with `OCP_TEMPLATES.capTable`, but now validates each returned row using `createdEvent.packageName` (must match the pinned package line) plus the module/entity suffix of `templateId`, and returns the raw ledger `templateId` for downstream commands; tests add regression coverage for hash-form IDs and new schema-mismatch cases (missing/empty `packageName`, bad module suffix, wrong package line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1238bc9983e3bd93ac59598648c6beea784bc02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made cap table template validation more flexible: validation now compares package line and module/entity suffix, accepts hashed template identifiers when package matches, and produces clearer package-line scoped mismatch messages.

* **Tests**
  * Expanded positive and negative test coverage for the enhanced validation behavior, including malformed identifiers and package-name mismatch cases; updated assertions and error-message expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->