### PR TITLE
fix(warrantIssuance): read back approval dates and related issuance fields

### DIFF
--- a/src/functions/OpenCapTable/warrantIssuance/getWarrantIssuanceAsOcf.ts
+++ b/src/functions/OpenCapTable/warrantIssuance/getWarrantIssuanceAsOcf.ts
@@ -280,11 +280,15 @@ export function damlWarrantIssuanceDataToNative(d: Record<string, unknown>): Ocf
     Array.isArray(d.vestings) && d.vestings.length > 0
       ? (d.vestings as Array<{ date: string; amount?: unknown }>).map((v) => {
           if (typeof v.amount !== 'string' && typeof v.amount !== 'number') {
-            throw new OcpValidationError('warrantIssuance.vestings.amount', `Must be string or number, got ${typeof v.amount}`, {
-              code: OcpErrorCodes.INVALID_TYPE,
-              expectedType: 'string | number',
-              receivedValue: v.amount,
-            });
+            throw new OcpValidationError(
+              'warrantIssuance.vestings.amount',
+              `Must be string or number, got ${typeof v.amount}`,
+              {
+                code: OcpErrorCodes.INVALID_TYPE,
+                expectedType: 'string | number',
+                receivedValue: v.amount,
+              }
+            );
           }
           const amountStr = typeof v.amount === 'number' ? v.amount.toString() : v.amount;
           if (typeof v.date !== 'string' || !v.date) {

--- a/src/functions/OpenCapTable/warrantIssuance/getWarrantIssuanceAsOcf.ts
+++ b/src/functions/OpenCapTable/warrantIssuance/getWarrantIssuanceAsOcf.ts
@@ -4,6 +4,7 @@ import type { GetByContractIdParams } from '../../../types/common';
 import type {
   ConversionTriggerType,
   OcfWarrantIssuance,
+  VestingSimple,
   WarrantConversionMechanism,
   WarrantConversionRight,
   WarrantExerciseTrigger,
@@ -204,6 +205,9 @@ function mapQuantitySource(qs: unknown): OcfWarrantIssuance['quantity_source'] |
 /**
  * Converts DAML WarrantIssuance data to native OCF format.
  * Used by the dispatcher pattern in damlToOcf.ts.
+ *
+ * Optional fields must stay aligned with `warrantIssuanceDataToDaml` in `createWarrantIssuance.ts`:
+ * replication compares raw DB OCF to Canton readback; missing optional keys cause false residual edits.
  */
 export function damlWarrantIssuanceDataToNative(d: Record<string, unknown>): OcfWarrantIssuance {
   const exercise_triggers: WarrantExerciseTrigger[] = Array.isArray(d.exercise_triggers)
@@ -271,6 +275,30 @@ export function damlWarrantIssuanceDataToNative(d: Record<string, unknown>): Ocf
   }
 
   const comments = Array.isArray(d.comments) && d.comments.length > 0 ? (d.comments as string[]) : undefined;
+
+  const vestings: VestingSimple[] | undefined =
+    Array.isArray(d.vestings) && d.vestings.length > 0
+      ? (d.vestings as Array<{ date: string; amount?: unknown }>).map((v) => {
+          if (typeof v.amount !== 'string' && typeof v.amount !== 'number') {
+            throw new OcpValidationError('warrantIssuance.vestings.amount', `Must be string or number, got ${typeof v.amount}`, {
+              code: OcpErrorCodes.INVALID_TYPE,
+              expectedType: 'string | number',
+              receivedValue: v.amount,
+            });
+          }
+          const amountStr = typeof v.amount === 'number' ? v.amount.toString() : v.amount;
+          if (typeof v.date !== 'string' || !v.date) {
+            throw new OcpValidationError('warrantIssuance.vestings.date', 'Required field is missing or invalid', {
+              code: OcpErrorCodes.REQUIRED_FIELD_MISSING,
+              receivedValue: v.date,
+            });
+          }
+          return {
+            date: v.date.split('T')[0],
+            amount: normalizeNumericString(amountStr),
+          };
+        })
+      : undefined;
 
   // Validate required string fields
   if (typeof d.id !== 'string' || !d.id) {
@@ -342,6 +370,16 @@ export function damlWarrantIssuanceDataToNative(d: Record<string, unknown>): Ocf
       ? { warrant_expiration_date: (d.warrant_expiration_date as string).split('T')[0] }
       : {}),
     ...(d.vesting_terms_id && typeof d.vesting_terms_id === 'string' ? { vesting_terms_id: d.vesting_terms_id } : {}),
+    ...(d.board_approval_date && typeof d.board_approval_date === 'string'
+      ? { board_approval_date: d.board_approval_date.split('T')[0] }
+      : {}),
+    ...(d.stockholder_approval_date && typeof d.stockholder_approval_date === 'string'
+      ? { stockholder_approval_date: d.stockholder_approval_date.split('T')[0] }
+      : {}),
+    ...(typeof d.consideration_text === 'string' && d.consideration_text.length > 0
+      ? { consideration_text: d.consideration_text }
+      : {}),
+    ...(vestings ? { vestings } : {}),
     security_law_exemptions: d.security_law_exemptions as Array<{
       description: string;
       jurisdiction: string;

--- a/test/converters/warrantIssuanceConverters.test.ts
+++ b/test/converters/warrantIssuanceConverters.test.ts
@@ -138,6 +138,20 @@ describe('WarrantIssuance round-trip equivalence', () => {
     expect(ocfDeepEqual(dbData as Record<string, unknown>, cantonData)).toBe(true);
   });
 
+  test('warrant issuance with approval dates, consideration_text, and vestings survives round-trip', () => {
+    const input = {
+      ...baseWarrantIssuance,
+      board_approval_date: '2024-06-01',
+      stockholder_approval_date: '2024-06-05',
+      consideration_text: 'Cash and services',
+      vestings: [{ date: '2024-01-01', amount: '100' }],
+    };
+    const dbData = { object_type: 'TX_WARRANT_ISSUANCE', ...input };
+    const cantonData = roundTrip(input);
+
+    expect(ocfDeepEqual(dbData as Record<string, unknown>, cantonData)).toBe(true);
+  });
+
   test('warrant issuance with numeric converts_to_quantity as JS number survives round-trip', () => {
     const input = {
       ...baseWarrantIssuance,


### PR DESCRIPTION
## Summary
`damlWarrantIssuanceDataToNative` dropped optional fields that `warrantIssuanceDataToDaml` persists (e.g. `board_approval_date`, `stockholder_approval_date`, `consideration_text`, `vestings`). Canton replication compares raw DB OCF to post-write Canton readback, so missing keys produced false residual edits and failed post-apply convergence (observed on devnet warrant issuance).

## Changes
- Map approval dates to `YYYY-MM-DD` on readback
- Pass through non-empty `consideration_text`
- Map `vestings` entries consistently with other issuance extractors
- Document parity requirement alongside `createWarrantIssuance.ts`
- Regression: round-trip test covering the new optional fields

## Test plan
- `npm run test:ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OCF↔DAML conversion for warrant issuances; mistakes could cause replication mismatches or missing/invalid optional issuance data. Scope is limited to readback mapping and a regression test.
> 
> **Overview**
> Fixes warrant issuance readback parity by extending `damlWarrantIssuanceDataToNative` to include previously dropped optional fields: `board_approval_date`, `stockholder_approval_date`, `consideration_text`, and `vestings` (with basic type validation and date/number normalization).
> 
> Adds a regression round-trip test to ensure these optional fields survive the OCF → DAML → OCF conversion without triggering false residual edits during replication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e56adce3a2e8bbc7330927185b3ef21c1a18d514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warrant issuance now accepts optional fields: board approval date, stockholder approval date, consideration text, and vesting schedules. These fields are validated and dates normalized when provided, and omitted when absent to prevent unintended edits.

* **Tests**
  * Added unit test coverage to ensure round-trip handling of approval dates, consideration text, and vesting information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->