### PR TITLE
fix(warrantIssuance): fail fast on unknown warrant conversion_mechanism

### DIFF
--- a/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
+++ b/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
@@ -146,7 +146,10 @@ function warrantSafeLikeToPpsDaml(
   if (anyM.conversion_mfn != null) {
     descParts.push(`conversion_mfn: ${Boolean(anyM.conversion_mfn)}`);
   }
-  const exitMultiple = anyM.exit_multiple as { numerator?: string | number; denominator?: string | number } | null | undefined;
+  const exitMultiple = anyM.exit_multiple as
+    | { numerator?: string | number; denominator?: string | number }
+    | null
+    | undefined;
   if (exitMultiple?.numerator != null && exitMultiple.denominator != null) {
     descParts.push(
       `exit_multiple: ${normalizeNumericString(exitMultiple.numerator)}/${normalizeNumericString(exitMultiple.denominator)}`
@@ -183,9 +186,7 @@ function warrantNoteLikeToCustomDaml(
   const parts: string[] = ['CONVERTIBLE_NOTE_CONVERSION mapped to warrant custom mechanism'];
   if (anyM.conversion_discount != null && anyM.conversion_discount !== '') {
     const d = anyM.conversion_discount as string | number;
-    parts.push(
-      `conversion_discount: ${normalizeNumericString(typeof d === 'number' ? d : String(d))}`
-    );
+    parts.push(`conversion_discount: ${normalizeNumericString(typeof d === 'number' ? d : String(d))}`);
   }
   const capMoney = anyM.conversion_valuation_cap;
   if (capMoney && typeof capMoney === 'object') {
@@ -259,9 +260,7 @@ function warrantMechanismToDamlVariant(
       return {
         tag: 'OcfWarrantMechanismPercentCapitalization',
         value: {
-          converts_to_percent: normalizeNumericString(
-            typeof ctp === 'number' ? ctp : String(ctp as string | number)
-          ),
+          converts_to_percent: normalizeNumericString(typeof ctp === 'number' ? ctp : String(ctp as string | number)),
           capitalization_definition: optionalString(obj.capitalization_definition as string | undefined),
           capitalization_definition_rules: mapWarrantCapitalizationRules(obj.capitalization_definition_rules),
         },
@@ -279,9 +278,7 @@ function warrantMechanismToDamlVariant(
       return {
         tag: 'OcfWarrantMechanismFixedAmount',
         value: {
-          converts_to_quantity: normalizeNumericString(
-            typeof ctq === 'number' ? ctq : String(ctq as string | number)
-          ),
+          converts_to_quantity: normalizeNumericString(typeof ctq === 'number' ? ctq : String(ctq as string | number)),
         },
       } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
     }

--- a/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
+++ b/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
@@ -7,6 +7,7 @@ import {
   monetaryToDaml,
   normalizeNumericString,
   optionalString,
+  safeString,
 } from '../../../utils/typeConversions';
 
 export interface SimpleVesting {
@@ -44,7 +45,19 @@ type WarrantConversionMechanismInput =
       discount: boolean;
       discount_percentage?: string | null;
       discount_amount?: Monetary | null;
-    };
+    }
+  /** DB/OCF payloads may attach convertible-style mechanisms; warrant DAML has no SAFE/note variants. */
+  | {
+      type: 'SAFE_CONVERSION';
+      conversion_discount?: string | number | null;
+      conversion_valuation_cap?: Monetary | null;
+      exit_multiple?: { numerator: string | number; denominator: string | number } | null;
+      conversion_mfn?: boolean | null;
+      conversion_timing?: string | null;
+      capitalization_definition?: string | null;
+      capitalization_definition_rules?: Record<string, unknown> | null;
+    }
+  | (Record<string, unknown> & { type: string });
 
 export type WarrantExerciseTriggerInput =
   | WarrantTriggerTypeInput
@@ -58,7 +71,7 @@ export type WarrantExerciseTriggerInput =
       start_date?: string; // YYYY-MM-DD or ISO datetime (ELECTIVE_IN_RANGE)
       end_date?: string; // YYYY-MM-DD or ISO datetime (ELECTIVE_IN_RANGE)
       conversion_right?: {
-        conversion_mechanism?: WarrantConversionMechanismInput;
+        conversion_mechanism?: WarrantConversionMechanismInput | string;
         converts_to_future_round?: boolean;
         converts_to_stock_class_id?: string;
       };
@@ -94,72 +107,234 @@ function triggerTypeToDamlEnum(
   }
 }
 
-function warrantMechanismToDamlVariant(
-  m?: WarrantConversionMechanismInput
+function mapWarrantCapitalizationRules(
+  rules: unknown
+): Fairmint.OpenCapTable.Types.Conversion.OcfCapitalizationDefinitionRules | null {
+  if (!rules || typeof rules !== 'object') return null;
+  const r = rules as Record<string, unknown>;
+  return {
+    include_outstanding_shares: Boolean(r.include_outstanding_shares),
+    include_outstanding_options: Boolean(r.include_outstanding_options),
+    include_outstanding_unissued_options: Boolean(r.include_outstanding_unissued_options),
+    include_this_security: Boolean(r.include_this_security),
+    include_other_converting_securities: Boolean(r.include_other_converting_securities),
+    include_option_pool_topup_for_promised_options: Boolean(r.include_option_pool_topup_for_promised_options),
+    include_additional_option_pool_topup: Boolean(r.include_additional_option_pool_topup),
+    include_new_money: Boolean(r.include_new_money),
+  } as Fairmint.OpenCapTable.Types.Conversion.OcfCapitalizationDefinitionRules;
+}
+
+/**
+ * Warrant DAML has no OcfConvMechSAFE. Map SAFE-style OCF fields to PPS-based warrant mechanism
+ * (discount + prose description for cap, MFN, timing, etc.).
+ */
+function warrantSafeLikeToPpsDaml(
+  anyM: Record<string, unknown>
 ): Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism {
-  if (!m) {
+  const descParts: string[] = ['SAFE-style conversion'];
+  if (typeof anyM.capitalization_definition === 'string' && anyM.capitalization_definition.length) {
+    descParts.push(`capitalization_definition: ${anyM.capitalization_definition}`);
+  }
+  const capRules = mapWarrantCapitalizationRules(anyM.capitalization_definition_rules);
+  if (capRules && Object.values(capRules).some(Boolean)) {
+    descParts.push(`capitalization_definition_rules: ${JSON.stringify(capRules)}`);
+  }
+  const timingRaw = anyM.conversion_timing;
+  if (timingRaw != null && safeString(timingRaw) !== '') {
+    descParts.push(`conversion_timing: ${safeString(timingRaw)}`);
+  }
+  if (anyM.conversion_mfn != null) {
+    descParts.push(`conversion_mfn: ${Boolean(anyM.conversion_mfn)}`);
+  }
+  const exitMultiple = anyM.exit_multiple as { numerator?: unknown; denominator?: unknown } | null | undefined;
+  if (exitMultiple && exitMultiple.numerator != null && exitMultiple.denominator != null) {
+    descParts.push(
+      `exit_multiple: ${normalizeNumericString(String(exitMultiple.numerator))}/${normalizeNumericString(String(exitMultiple.denominator))}`
+    );
+  }
+  const capMoney = anyM.conversion_valuation_cap;
+  if (capMoney && typeof capMoney === 'object') {
+    const m = monetaryToDaml(capMoney as Monetary);
+    descParts.push(`conversion_valuation_cap: ${m.amount} ${m.currency}`);
+  }
+
+  const discountRaw = anyM.conversion_discount;
+  const hasDiscount = discountRaw != null && discountRaw !== '';
+  const discount_percentage =
+    hasDiscount && (typeof discountRaw === 'string' || typeof discountRaw === 'number')
+      ? normalizeNumericString(discountRaw)
+      : null;
+
+  return {
+    tag: 'OcfWarrantMechanismPpsBased',
+    value: {
+      description: descParts.join('; '),
+      discount: Boolean(hasDiscount),
+      discount_percentage,
+      discount_amount: null,
+    },
+  } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
+}
+
+/** Note mechanics have no warrant analogue; preserve salient terms in custom description. */
+function warrantNoteLikeToCustomDaml(
+  anyM: Record<string, unknown>
+): Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism {
+  const parts: string[] = ['CONVERTIBLE_NOTE_CONVERSION mapped to warrant custom mechanism'];
+  if (anyM.conversion_discount != null && anyM.conversion_discount !== '') {
+    const d = anyM.conversion_discount;
+    parts.push(
+      `conversion_discount: ${normalizeNumericString(typeof d === 'number' ? d : String(d))}`
+    );
+  }
+  const capMoney = anyM.conversion_valuation_cap;
+  if (capMoney && typeof capMoney === 'object') {
+    const m = monetaryToDaml(capMoney as Monetary);
+    parts.push(`conversion_valuation_cap: ${m.amount} ${m.currency}`);
+  }
+  if (Array.isArray(anyM.interest_rates)) {
+    parts.push(`interest_rates_count: ${anyM.interest_rates.length}`);
+  }
+  if (anyM.day_count_convention != null) {
+    parts.push(`day_count_convention: ${safeString(anyM.day_count_convention)}`);
+  }
+  if (anyM.interest_payout != null) {
+    parts.push(`interest_payout: ${safeString(anyM.interest_payout)}`);
+  }
+  if (anyM.interest_accrual_period != null) {
+    parts.push(`interest_accrual_period: ${safeString(anyM.interest_accrual_period)}`);
+  }
+  if (anyM.compounding_type != null) {
+    parts.push(`compounding_type: ${safeString(anyM.compounding_type)}`);
+  }
+  if (anyM.conversion_mfn != null) {
+    parts.push(`conversion_mfn: ${Boolean(anyM.conversion_mfn)}`);
+  }
+  return {
+    tag: 'OcfWarrantMechanismCustom',
+    value: { custom_conversion_description: parts.join('; ') },
+  } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
+}
+
+function warrantMechanismToDamlVariant(
+  m?: WarrantConversionMechanismInput | string
+): Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism {
+  if (m === undefined || m === null) {
     throw new OcpValidationError(
       'conversion_right.conversion_mechanism',
       'conversion_right.conversion_mechanism is required for warrant issuance',
       { code: OcpErrorCodes.REQUIRED_FIELD_MISSING }
     );
   }
-  switch (m.type) {
-    case 'CUSTOM_CONVERSION':
+  const obj: Record<string, unknown> = typeof m === 'string' ? { type: m } : (m as Record<string, unknown>);
+  const typeStr = String(obj.type ?? '').toUpperCase();
+
+  switch (typeStr) {
+    case 'CUSTOM_CONVERSION': {
+      const desc =
+        (obj.custom_conversion_description as string) ||
+        (obj.custom_description as string) ||
+        (typeof obj.description === 'string' ? obj.description : '');
+      if (!desc) {
+        throw new OcpValidationError(
+          'conversion_right.conversion_mechanism',
+          'CUSTOM_CONVERSION requires custom_conversion_description',
+          { code: OcpErrorCodes.REQUIRED_FIELD_MISSING }
+        );
+      }
       return {
         tag: 'OcfWarrantMechanismCustom',
-        value: { custom_conversion_description: m.custom_conversion_description },
+        value: { custom_conversion_description: desc },
       } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
-    case 'FIXED_PERCENT_OF_CAPITALIZATION_CONVERSION':
+    }
+    case 'FIXED_PERCENT_OF_CAPITALIZATION_CONVERSION': {
+      const ctp = obj.converts_to_percent;
+      if (ctp === undefined || ctp === null) {
+        throw new OcpValidationError(
+          'conversion_right.conversion_mechanism',
+          'FIXED_PERCENT_OF_CAPITALIZATION_CONVERSION requires converts_to_percent',
+          { code: OcpErrorCodes.REQUIRED_FIELD_MISSING }
+        );
+      }
       return {
         tag: 'OcfWarrantMechanismPercentCapitalization',
         value: {
-          converts_to_percent: normalizeNumericString(m.converts_to_percent),
-          capitalization_definition: optionalString(m.capitalization_definition),
-          capitalization_definition_rules: (m.capitalization_definition_rules ??
-            null) as Fairmint.OpenCapTable.Types.Conversion.OcfCapitalizationDefinitionRules | null,
+          converts_to_percent: normalizeNumericString(
+            typeof ctp === 'number' ? ctp : String(ctp)
+          ),
+          capitalization_definition: optionalString(obj.capitalization_definition as string | undefined),
+          capitalization_definition_rules: mapWarrantCapitalizationRules(obj.capitalization_definition_rules),
         },
       } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
-    case 'FIXED_AMOUNT_CONVERSION':
+    }
+    case 'FIXED_AMOUNT_CONVERSION': {
+      const ctq = obj.converts_to_quantity;
+      if (ctq === undefined || ctq === null) {
+        throw new OcpValidationError(
+          'conversion_right.conversion_mechanism',
+          'FIXED_AMOUNT_CONVERSION requires converts_to_quantity',
+          { code: OcpErrorCodes.REQUIRED_FIELD_MISSING }
+        );
+      }
       return {
         tag: 'OcfWarrantMechanismFixedAmount',
         value: {
-          converts_to_quantity: normalizeNumericString(m.converts_to_quantity),
+          converts_to_quantity: normalizeNumericString(
+            typeof ctq === 'number' ? ctq : String(ctq)
+          ),
         },
       } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
-    case 'VALUATION_BASED_CONVERSION':
+    }
+    case 'VALUATION_BASED_CONVERSION': {
+      if (!obj.valuation_type || typeof obj.valuation_type !== 'string') {
+        throw new OcpValidationError(
+          'conversion_right.conversion_mechanism',
+          'VALUATION_BASED_CONVERSION requires valuation_type',
+          { code: OcpErrorCodes.REQUIRED_FIELD_MISSING }
+        );
+      }
       return {
         tag: 'OcfWarrantMechanismValuationBased',
         value: {
-          valuation_type: m.valuation_type,
-          valuation_amount: m.valuation_amount ? monetaryToDaml(m.valuation_amount) : null,
-          capitalization_definition: optionalString(m.capitalization_definition),
-          capitalization_definition_rules: (m.capitalization_definition_rules ??
-            null) as Fairmint.OpenCapTable.Types.Conversion.OcfCapitalizationDefinitionRules | null,
+          valuation_type: obj.valuation_type,
+          valuation_amount: obj.valuation_amount ? monetaryToDaml(obj.valuation_amount as Monetary) : null,
+          capitalization_definition: optionalString(obj.capitalization_definition as string | undefined),
+          capitalization_definition_rules: mapWarrantCapitalizationRules(obj.capitalization_definition_rules),
         },
       } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
-    case 'PPS_BASED_CONVERSION':
+    }
+    case 'PPS_BASED_CONVERSION': {
+      if (typeof obj.description !== 'string' || !obj.description) {
+        throw new OcpValidationError(
+          'conversion_right.conversion_mechanism',
+          'PPS_BASED_CONVERSION requires description',
+          { code: OcpErrorCodes.REQUIRED_FIELD_MISSING }
+        );
+      }
+      const dpct = obj.discount_percentage;
       return {
         tag: 'OcfWarrantMechanismPpsBased',
         value: {
-          description: m.description,
-          discount: m.discount,
+          description: obj.description,
+          discount: Boolean(obj.discount),
           discount_percentage:
-            m.discount_percentage === '' || m.discount_percentage == null
+            dpct === '' || dpct == null
               ? null
-              : normalizeNumericString(m.discount_percentage),
-          discount_amount: m.discount_amount ? monetaryToDaml(m.discount_amount) : null,
+              : normalizeNumericString(typeof dpct === 'number' ? dpct : String(dpct)),
+          discount_amount: obj.discount_amount ? monetaryToDaml(obj.discount_amount as Monetary) : null,
         },
       } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
-    default: {
-      const rawType =
-        m && typeof m === 'object' && 'type' in m ? String((m as { type?: unknown }).type) : 'unknown';
+    }
+    case 'SAFE_CONVERSION':
+      return warrantSafeLikeToPpsDaml(obj);
+    case 'CONVERTIBLE_NOTE_CONVERSION':
+      return warrantNoteLikeToCustomDaml(obj);
+    default:
       throw new OcpValidationError(
         'conversion_right.conversion_mechanism',
-        `Unsupported warrant conversion_mechanism type: ${rawType}. Canton warrant templates only support CUSTOM_CONVERSION, FIXED_PERCENT_OF_CAPITALIZATION_CONVERSION, FIXED_AMOUNT_CONVERSION, VALUATION_BASED_CONVERSION, and PPS_BASED_CONVERSION. If the cap table uses SAFE_CONVERSION or convertible-style mechanisms on a warrant, normalize the OCF or extend DAML (warrants use OcfWarrantConversionMechanism, not OcfConvertibleConversionMechanism).`,
+        `Unsupported warrant conversion_mechanism type: ${typeStr || 'unknown'}. Canton warrant templates support warrant mechanisms only (plus SAFE_CONVERSION and CONVERTIBLE_NOTE_CONVERSION, which are mapped to PPS-based and custom warrant mechanisms).`,
         { code: OcpErrorCodes.UNKNOWN_ENUM_VALUE }
       );
-    }
   }
 }
 

--- a/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
+++ b/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
@@ -7,7 +7,6 @@ import {
   monetaryToDaml,
   normalizeNumericString,
   optionalString,
-  safeString,
 } from '../../../utils/typeConversions';
 
 export interface SimpleVesting {
@@ -45,19 +44,7 @@ type WarrantConversionMechanismInput =
       discount: boolean;
       discount_percentage?: string | null;
       discount_amount?: Monetary | null;
-    }
-  /** DB/OCF payloads may attach convertible-style mechanisms; warrant DAML has no SAFE/note variants. */
-  | {
-      type: 'SAFE_CONVERSION';
-      conversion_discount?: string | number | null;
-      conversion_valuation_cap?: Monetary | null;
-      exit_multiple?: { numerator: string | number; denominator: string | number } | null;
-      conversion_mfn?: boolean | null;
-      conversion_timing?: string | null;
-      capitalization_definition?: string | null;
-      capitalization_definition_rules?: Record<string, unknown> | null;
-    }
-  | (Record<string, unknown> & { type: string });
+    };
 
 export type WarrantExerciseTriggerInput =
   | WarrantTriggerTypeInput
@@ -71,7 +58,7 @@ export type WarrantExerciseTriggerInput =
       start_date?: string; // YYYY-MM-DD or ISO datetime (ELECTIVE_IN_RANGE)
       end_date?: string; // YYYY-MM-DD or ISO datetime (ELECTIVE_IN_RANGE)
       conversion_right?: {
-        conversion_mechanism?: WarrantConversionMechanismInput | string;
+        conversion_mechanism?: WarrantConversionMechanismInput;
         converts_to_future_round?: boolean;
         converts_to_stock_class_id?: string;
       };
@@ -124,100 +111,8 @@ function mapWarrantCapitalizationRules(
   } as Fairmint.OpenCapTable.Types.Conversion.OcfCapitalizationDefinitionRules;
 }
 
-/**
- * Warrant DAML has no OcfConvMechSAFE. Map SAFE-style OCF fields to PPS-based warrant mechanism
- * (discount + prose description for cap, MFN, timing, etc.).
- */
-function warrantSafeLikeToPpsDaml(
-  anyM: Record<string, unknown>
-): Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism {
-  const descParts: string[] = ['SAFE-style conversion'];
-  if (typeof anyM.capitalization_definition === 'string' && anyM.capitalization_definition.length) {
-    descParts.push(`capitalization_definition: ${anyM.capitalization_definition}`);
-  }
-  const capRules = mapWarrantCapitalizationRules(anyM.capitalization_definition_rules);
-  if (capRules && Object.values(capRules).some(Boolean)) {
-    descParts.push(`capitalization_definition_rules: ${JSON.stringify(capRules)}`);
-  }
-  const timingRaw = anyM.conversion_timing;
-  if (timingRaw != null && safeString(timingRaw) !== '') {
-    descParts.push(`conversion_timing: ${safeString(timingRaw)}`);
-  }
-  if (anyM.conversion_mfn != null) {
-    descParts.push(`conversion_mfn: ${Boolean(anyM.conversion_mfn)}`);
-  }
-  const exitMultiple = anyM.exit_multiple as { numerator?: string | number; denominator?: string | number } | null | undefined;
-  if (exitMultiple?.numerator != null && exitMultiple.denominator != null) {
-    descParts.push(
-      `exit_multiple: ${normalizeNumericString(exitMultiple.numerator)}/${normalizeNumericString(exitMultiple.denominator)}`
-    );
-  }
-  const capMoney = anyM.conversion_valuation_cap;
-  if (capMoney && typeof capMoney === 'object') {
-    const m = monetaryToDaml(capMoney as Monetary);
-    descParts.push(`conversion_valuation_cap: ${m.amount} ${m.currency}`);
-  }
-
-  const discountRaw = anyM.conversion_discount;
-  const hasDiscount = discountRaw != null && discountRaw !== '';
-  const discount_percentage =
-    hasDiscount && (typeof discountRaw === 'string' || typeof discountRaw === 'number')
-      ? normalizeNumericString(discountRaw)
-      : null;
-
-  return {
-    tag: 'OcfWarrantMechanismPpsBased',
-    value: {
-      description: descParts.join('; '),
-      discount: Boolean(hasDiscount),
-      discount_percentage,
-      discount_amount: null,
-    },
-  } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
-}
-
-/** Note mechanics have no warrant analogue; preserve salient terms in custom description. */
-function warrantNoteLikeToCustomDaml(
-  anyM: Record<string, unknown>
-): Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism {
-  const parts: string[] = ['CONVERTIBLE_NOTE_CONVERSION mapped to warrant custom mechanism'];
-  if (anyM.conversion_discount != null && anyM.conversion_discount !== '') {
-    const d = anyM.conversion_discount as string | number;
-    parts.push(
-      `conversion_discount: ${normalizeNumericString(typeof d === 'number' ? d : String(d))}`
-    );
-  }
-  const capMoney = anyM.conversion_valuation_cap;
-  if (capMoney && typeof capMoney === 'object') {
-    const m = monetaryToDaml(capMoney as Monetary);
-    parts.push(`conversion_valuation_cap: ${m.amount} ${m.currency}`);
-  }
-  if (Array.isArray(anyM.interest_rates)) {
-    parts.push(`interest_rates_count: ${anyM.interest_rates.length}`);
-  }
-  if (anyM.day_count_convention != null) {
-    parts.push(`day_count_convention: ${safeString(anyM.day_count_convention)}`);
-  }
-  if (anyM.interest_payout != null) {
-    parts.push(`interest_payout: ${safeString(anyM.interest_payout)}`);
-  }
-  if (anyM.interest_accrual_period != null) {
-    parts.push(`interest_accrual_period: ${safeString(anyM.interest_accrual_period)}`);
-  }
-  if (anyM.compounding_type != null) {
-    parts.push(`compounding_type: ${safeString(anyM.compounding_type)}`);
-  }
-  if (anyM.conversion_mfn != null) {
-    parts.push(`conversion_mfn: ${Boolean(anyM.conversion_mfn)}`);
-  }
-  return {
-    tag: 'OcfWarrantMechanismCustom',
-    value: { custom_conversion_description: parts.join('; ') },
-  } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
-}
-
 function warrantMechanismToDamlVariant(
-  m?: WarrantConversionMechanismInput | string
+  m?: WarrantConversionMechanismInput
 ): Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism {
   if (m === undefined) {
     throw new OcpValidationError(
@@ -226,7 +121,7 @@ function warrantMechanismToDamlVariant(
       { code: OcpErrorCodes.REQUIRED_FIELD_MISSING }
     );
   }
-  const obj: Record<string, unknown> = typeof m === 'string' ? { type: m } : (m as Record<string, unknown>);
+  const obj: Record<string, unknown> = m as Record<string, unknown>;
   const typeStr = (typeof obj.type === 'string' ? obj.type : '').toUpperCase();
 
   switch (typeStr) {
@@ -325,13 +220,9 @@ function warrantMechanismToDamlVariant(
         },
       } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
     }
-    case 'SAFE_CONVERSION':
-      return warrantSafeLikeToPpsDaml(obj);
-    case 'CONVERTIBLE_NOTE_CONVERSION':
-      return warrantNoteLikeToCustomDaml(obj);
     default:
       throw new OcpParseError(
-        `Unsupported warrant conversion_mechanism.type: ${typeStr || 'unknown'}. Supported: CUSTOM_CONVERSION, FIXED_PERCENT_OF_CAPITALIZATION_CONVERSION, FIXED_AMOUNT_CONVERSION, VALUATION_BASED_CONVERSION, PPS_BASED_CONVERSION, SAFE_CONVERSION, CONVERTIBLE_NOTE_CONVERSION.`,
+        `Unknown warrant conversion_mechanism.type: "${typeStr || 'unknown'}". Valid types for warrants: CUSTOM_CONVERSION, FIXED_PERCENT_OF_CAPITALIZATION_CONVERSION, FIXED_AMOUNT_CONVERSION, VALUATION_BASED_CONVERSION, PPS_BASED_CONVERSION. Types like SAFE_CONVERSION and CONVERTIBLE_NOTE_CONVERSION are invalid for warrant issuance per OCF schema and DAML — fix the upstream producer or represent the mechanism as PPS_BASED_CONVERSION or CUSTOM_CONVERSION.`,
         { code: OcpErrorCodes.UNKNOWN_ENUM_VALUE }
       );
   }

--- a/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
+++ b/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
@@ -146,10 +146,10 @@ function warrantSafeLikeToPpsDaml(
   if (anyM.conversion_mfn != null) {
     descParts.push(`conversion_mfn: ${Boolean(anyM.conversion_mfn)}`);
   }
-  const exitMultiple = anyM.exit_multiple as { numerator?: unknown; denominator?: unknown } | null | undefined;
-  if (exitMultiple && exitMultiple.numerator != null && exitMultiple.denominator != null) {
+  const exitMultiple = anyM.exit_multiple as { numerator?: string | number; denominator?: string | number } | null | undefined;
+  if (exitMultiple?.numerator != null && exitMultiple.denominator != null) {
     descParts.push(
-      `exit_multiple: ${normalizeNumericString(String(exitMultiple.numerator))}/${normalizeNumericString(String(exitMultiple.denominator))}`
+      `exit_multiple: ${normalizeNumericString(exitMultiple.numerator)}/${normalizeNumericString(exitMultiple.denominator)}`
     );
   }
   const capMoney = anyM.conversion_valuation_cap;
@@ -182,7 +182,7 @@ function warrantNoteLikeToCustomDaml(
 ): Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism {
   const parts: string[] = ['CONVERTIBLE_NOTE_CONVERSION mapped to warrant custom mechanism'];
   if (anyM.conversion_discount != null && anyM.conversion_discount !== '') {
-    const d = anyM.conversion_discount;
+    const d = anyM.conversion_discount as string | number;
     parts.push(
       `conversion_discount: ${normalizeNumericString(typeof d === 'number' ? d : String(d))}`
     );
@@ -219,7 +219,7 @@ function warrantNoteLikeToCustomDaml(
 function warrantMechanismToDamlVariant(
   m?: WarrantConversionMechanismInput | string
 ): Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism {
-  if (m === undefined || m === null) {
+  if (m === undefined) {
     throw new OcpValidationError(
       'conversion_right.conversion_mechanism',
       'conversion_right.conversion_mechanism is required for warrant issuance',
@@ -227,7 +227,7 @@ function warrantMechanismToDamlVariant(
     );
   }
   const obj: Record<string, unknown> = typeof m === 'string' ? { type: m } : (m as Record<string, unknown>);
-  const typeStr = String(obj.type ?? '').toUpperCase();
+  const typeStr = (typeof obj.type === 'string' ? obj.type : '').toUpperCase();
 
   switch (typeStr) {
     case 'CUSTOM_CONVERSION': {
@@ -260,7 +260,7 @@ function warrantMechanismToDamlVariant(
         tag: 'OcfWarrantMechanismPercentCapitalization',
         value: {
           converts_to_percent: normalizeNumericString(
-            typeof ctp === 'number' ? ctp : String(ctp)
+            typeof ctp === 'number' ? ctp : String(ctp as string | number)
           ),
           capitalization_definition: optionalString(obj.capitalization_definition as string | undefined),
           capitalization_definition_rules: mapWarrantCapitalizationRules(obj.capitalization_definition_rules),
@@ -280,7 +280,7 @@ function warrantMechanismToDamlVariant(
         tag: 'OcfWarrantMechanismFixedAmount',
         value: {
           converts_to_quantity: normalizeNumericString(
-            typeof ctq === 'number' ? ctq : String(ctq)
+            typeof ctq === 'number' ? ctq : String(ctq as string | number)
           ),
         },
       } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
@@ -320,7 +320,7 @@ function warrantMechanismToDamlVariant(
           discount_percentage:
             dpct === '' || dpct == null
               ? null
-              : normalizeNumericString(typeof dpct === 'number' ? dpct : String(dpct)),
+              : normalizeNumericString(typeof dpct === 'number' ? dpct : String(dpct as string | number)),
           discount_amount: obj.discount_amount ? monetaryToDaml(obj.discount_amount as Monetary) : null,
         },
       } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
@@ -330,9 +330,8 @@ function warrantMechanismToDamlVariant(
     case 'CONVERTIBLE_NOTE_CONVERSION':
       return warrantNoteLikeToCustomDaml(obj);
     default:
-      throw new OcpValidationError(
-        'conversion_right.conversion_mechanism',
-        `Unsupported warrant conversion_mechanism type: ${typeStr || 'unknown'}. Canton warrant templates support warrant mechanisms only (plus SAFE_CONVERSION and CONVERTIBLE_NOTE_CONVERSION, which are mapped to PPS-based and custom warrant mechanisms).`,
+      throw new OcpParseError(
+        `Unsupported warrant conversion_mechanism.type: ${typeStr || 'unknown'}. Supported: CUSTOM_CONVERSION, FIXED_PERCENT_OF_CAPITALIZATION_CONVERSION, FIXED_AMOUNT_CONVERSION, VALUATION_BASED_CONVERSION, PPS_BASED_CONVERSION, SAFE_CONVERSION, CONVERTIBLE_NOTE_CONVERSION.`,
         { code: OcpErrorCodes.UNKNOWN_ENUM_VALUE }
       );
   }

--- a/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
+++ b/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
@@ -154,9 +154,7 @@ function warrantMechanismToDamlVariant(
       return {
         tag: 'OcfWarrantMechanismPercentCapitalization',
         value: {
-          converts_to_percent: normalizeNumericString(
-            typeof ctp === 'number' ? ctp : String(ctp as string | number)
-          ),
+          converts_to_percent: normalizeNumericString(typeof ctp === 'number' ? ctp : String(ctp as string | number)),
           capitalization_definition: optionalString(obj.capitalization_definition as string | undefined),
           capitalization_definition_rules: mapWarrantCapitalizationRules(obj.capitalization_definition_rules),
         },
@@ -174,9 +172,7 @@ function warrantMechanismToDamlVariant(
       return {
         tag: 'OcfWarrantMechanismFixedAmount',
         value: {
-          converts_to_quantity: normalizeNumericString(
-            typeof ctq === 'number' ? ctq : String(ctq as string | number)
-          ),
+          converts_to_quantity: normalizeNumericString(typeof ctq === 'number' ? ctq : String(ctq as string | number)),
         },
       } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
     }

--- a/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
+++ b/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
@@ -151,6 +151,15 @@ function warrantMechanismToDamlVariant(
           discount_amount: m.discount_amount ? monetaryToDaml(m.discount_amount) : null,
         },
       } as Fairmint.OpenCapTable.Types.Conversion.OcfWarrantConversionMechanism;
+    default: {
+      const rawType =
+        m && typeof m === 'object' && 'type' in m ? String((m as { type?: unknown }).type) : 'unknown';
+      throw new OcpValidationError(
+        'conversion_right.conversion_mechanism',
+        `Unsupported warrant conversion_mechanism type: ${rawType}. Canton warrant templates only support CUSTOM_CONVERSION, FIXED_PERCENT_OF_CAPITALIZATION_CONVERSION, FIXED_AMOUNT_CONVERSION, VALUATION_BASED_CONVERSION, and PPS_BASED_CONVERSION. If the cap table uses SAFE_CONVERSION or convertible-style mechanisms on a warrant, normalize the OCF or extend DAML (warrants use OcfWarrantConversionMechanism, not OcfConvertibleConversionMechanism).`,
+        { code: OcpErrorCodes.UNKNOWN_ENUM_VALUE }
+      );
+    }
   }
 }
 

--- a/test/converters/warrantIssuanceConverters.test.ts
+++ b/test/converters/warrantIssuanceConverters.test.ts
@@ -6,7 +6,7 @@
  * infinite edit loops in the replication script.
  */
 
-import { OcpValidationError } from '../../src/errors';
+import { OcpParseError } from '../../src/errors';
 import { warrantIssuanceDataToDaml } from '../../src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance';
 import { damlWarrantIssuanceDataToNative } from '../../src/functions/OpenCapTable/warrantIssuance/getWarrantIssuanceAsOcf';
 import { ocfDeepEqual } from '../../src/utils/ocfComparison';
@@ -253,9 +253,9 @@ describe('WarrantIssuance round-trip equivalence', () => {
         },
       ],
     } as Parameters<typeof warrantIssuanceDataToDaml>[0];
-    expect(() => warrantIssuanceDataToDaml(input)).toThrow(OcpValidationError);
+    expect(() => warrantIssuanceDataToDaml(input)).toThrow(OcpParseError);
     expect(() => warrantIssuanceDataToDaml(input)).toThrow(
-      /Unsupported warrant conversion_mechanism type: NOT_A_REAL_MECHANISM/
+      /Unsupported warrant conversion_mechanism\.type: NOT_A_REAL_MECHANISM/
     );
   });
 

--- a/test/converters/warrantIssuanceConverters.test.ts
+++ b/test/converters/warrantIssuanceConverters.test.ts
@@ -153,9 +153,9 @@ describe('WarrantIssuance round-trip equivalence', () => {
     expect(ocfDeepEqual(dbData as Record<string, unknown>, cantonData)).toBe(true);
   });
 
-  test('SAFE_CONVERSION on warrant maps to PPS-based mechanism (JSON-safe, no undefined)', () => {
-    // Regression: JSON from DB may use convertible-style SAFE_CONVERSION; warrant DAML has no SAFE variant.
-    // Previously the switch fell through and produced undefined → CapTableBatch.assertJsonSafe failed opaquely.
+  test('SAFE_CONVERSION on warrant throws OcpParseError with actionable message', () => {
+    // SAFE_CONVERSION is invalid for warrant issuance per OCF schema and DAML.
+    // The SDK must fail fast rather than silently produce a lossy mapping.
     const input = {
       ...baseWarrantIssuance,
       exercise_triggers: [
@@ -164,99 +164,59 @@ describe('WarrantIssuance round-trip equivalence', () => {
           conversion_right: {
             ...baseWarrantIssuance.exercise_triggers[0].conversion_right,
             conversion_mechanism: {
-              type: 'SAFE_CONVERSION' as const,
-              conversion_discount: '0.2',
-              conversion_valuation_cap: { amount: '10000000', currency: 'USD' },
-              conversion_mfn: true,
-              conversion_timing: 'POST_MONEY',
+              type: 'SAFE_CONVERSION' as unknown as 'CUSTOM_CONVERSION',
+              custom_conversion_description: '',
             },
-          },
-        },
-      ],
-    };
-    const daml = warrantIssuanceDataToDaml(input);
-    const json = JSON.stringify(daml);
-    expect(json).not.toMatch(/undefined/);
-    const mech = daml.exercise_triggers[0].conversion_right as {
-      tag: string;
-      value: { conversion_mechanism: { tag: string; value: Record<string, unknown> } };
-    };
-    expect(mech.tag).toBe('OcfRightWarrant');
-    expect(mech.value.conversion_mechanism.tag).toBe('OcfWarrantMechanismPpsBased');
-    const pps = mech.value.conversion_mechanism.value;
-    expect(pps.discount).toBe(true);
-    expect(pps.discount_percentage).toBe('0.2');
-    expect(pps.discount_amount).toBeNull();
-    expect(String(pps.description)).toContain('SAFE-style conversion');
-    expect(String(pps.description)).toContain('conversion_valuation_cap');
-  });
-
-  test('bare string SAFE_CONVERSION shorthand maps to PPS-based warrant mechanism', () => {
-    const input = {
-      ...baseWarrantIssuance,
-      exercise_triggers: [
-        {
-          ...baseWarrantIssuance.exercise_triggers[0],
-          conversion_right: {
-            ...baseWarrantIssuance.exercise_triggers[0].conversion_right,
-            conversion_mechanism: 'SAFE_CONVERSION',
-          },
-        },
-      ],
-    };
-    const daml = warrantIssuanceDataToDaml(input);
-    expect(() => JSON.stringify(daml)).not.toThrow();
-    const mech = daml.exercise_triggers[0].conversion_right as {
-      value: { conversion_mechanism: { tag: string } };
-    };
-    expect(mech.value.conversion_mechanism.tag).toBe('OcfWarrantMechanismPpsBased');
-  });
-
-  test('CONVERTIBLE_NOTE_CONVERSION on warrant maps to custom mechanism (JSON-safe)', () => {
-    const input = {
-      ...baseWarrantIssuance,
-      exercise_triggers: [
-        {
-          ...baseWarrantIssuance.exercise_triggers[0],
-          conversion_right: {
-            ...baseWarrantIssuance.exercise_triggers[0].conversion_right,
-            conversion_mechanism: {
-              type: 'CONVERTIBLE_NOTE_CONVERSION' as const,
-              conversion_discount: '0.15',
-              interest_rates: [{ rate: '0.08', accrual_start_date: '2020-01-01', accrual_end_date: null }],
-              day_count_convention: 'ACTUAL_365',
-              interest_payout: 'DEFERRED',
-            },
-          },
-        },
-      ],
-    };
-    const daml = warrantIssuanceDataToDaml(input);
-    expect(() => JSON.stringify(daml)).not.toThrow();
-    const mech = daml.exercise_triggers[0].conversion_right as {
-      value: { conversion_mechanism: { tag: string; value: { custom_conversion_description: string } } };
-    };
-    expect(mech.value.conversion_mechanism.tag).toBe('OcfWarrantMechanismCustom');
-    expect(mech.value.conversion_mechanism.value.custom_conversion_description).toContain('CONVERTIBLE_NOTE');
-  });
-
-  test('unknown conversion_mechanism type still throws (never emits undefined)', () => {
-    const input = {
-      ...baseWarrantIssuance,
-      exercise_triggers: [
-        {
-          ...baseWarrantIssuance.exercise_triggers[0],
-          conversion_right: {
-            ...baseWarrantIssuance.exercise_triggers[0].conversion_right,
-            conversion_mechanism: { type: 'NOT_A_REAL_MECHANISM' },
           },
         },
       ],
     } as Parameters<typeof warrantIssuanceDataToDaml>[0];
     expect(() => warrantIssuanceDataToDaml(input)).toThrow(OcpParseError);
-    expect(() => warrantIssuanceDataToDaml(input)).toThrow(
-      /Unsupported warrant conversion_mechanism\.type: NOT_A_REAL_MECHANISM/
-    );
+    expect(() => warrantIssuanceDataToDaml(input)).toThrow(/SAFE_CONVERSION/);
+    expect(() => warrantIssuanceDataToDaml(input)).toThrow(/invalid for warrant issuance/);
+  });
+
+  test('CONVERTIBLE_NOTE_CONVERSION on warrant throws OcpParseError with actionable message', () => {
+    // CONVERTIBLE_NOTE_CONVERSION is invalid for warrant issuance per OCF schema and DAML.
+    const input = {
+      ...baseWarrantIssuance,
+      exercise_triggers: [
+        {
+          ...baseWarrantIssuance.exercise_triggers[0],
+          conversion_right: {
+            ...baseWarrantIssuance.exercise_triggers[0].conversion_right,
+            conversion_mechanism: {
+              type: 'CONVERTIBLE_NOTE_CONVERSION' as unknown as 'CUSTOM_CONVERSION',
+              custom_conversion_description: '',
+            },
+          },
+        },
+      ],
+    } as Parameters<typeof warrantIssuanceDataToDaml>[0];
+    expect(() => warrantIssuanceDataToDaml(input)).toThrow(OcpParseError);
+    expect(() => warrantIssuanceDataToDaml(input)).toThrow(/CONVERTIBLE_NOTE_CONVERSION/);
+    expect(() => warrantIssuanceDataToDaml(input)).toThrow(/invalid for warrant issuance/);
+  });
+
+  test('unknown conversion_mechanism type throws OcpParseError (never emits undefined)', () => {
+    const input = {
+      ...baseWarrantIssuance,
+      exercise_triggers: [
+        {
+          ...baseWarrantIssuance.exercise_triggers[0],
+          conversion_right: {
+            ...baseWarrantIssuance.exercise_triggers[0].conversion_right,
+            conversion_mechanism: {
+              type: 'NOT_A_REAL_MECHANISM' as unknown as 'CUSTOM_CONVERSION',
+              custom_conversion_description: '',
+            },
+          },
+        },
+      ],
+    } as Parameters<typeof warrantIssuanceDataToDaml>[0];
+    expect(() => warrantIssuanceDataToDaml(input)).toThrow(OcpParseError);
+    expect(() => warrantIssuanceDataToDaml(input)).toThrow(/Unknown warrant conversion_mechanism\.type/);
+    expect(() => warrantIssuanceDataToDaml(input)).toThrow(/NOT_A_REAL_MECHANISM/);
   });
 
   test('warrant issuance with numeric converts_to_quantity as JS number survives round-trip', () => {

--- a/test/converters/warrantIssuanceConverters.test.ts
+++ b/test/converters/warrantIssuanceConverters.test.ts
@@ -6,6 +6,7 @@
  * infinite edit loops in the replication script.
  */
 
+import { OcpValidationError } from '../../src/errors';
 import { warrantIssuanceDataToDaml } from '../../src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance';
 import { damlWarrantIssuanceDataToNative } from '../../src/functions/OpenCapTable/warrantIssuance/getWarrantIssuanceAsOcf';
 import { ocfDeepEqual } from '../../src/utils/ocfComparison';
@@ -150,6 +151,28 @@ describe('WarrantIssuance round-trip equivalence', () => {
     const cantonData = roundTrip(input);
 
     expect(ocfDeepEqual(dbData as Record<string, unknown>, cantonData)).toBe(true);
+  });
+
+  test('rejects SAFE_CONVERSION on warrant with validation error (never emits undefined conversion_mechanism)', () => {
+    // Regression: JSON from DB may use convertible-style SAFE_CONVERSION; warrant DAML has no SAFE variant.
+    // Previously the switch fell through and produced undefined → CapTableBatch.assertJsonSafe failed opaquely.
+    const input = {
+      ...baseWarrantIssuance,
+      exercise_triggers: [
+        {
+          ...baseWarrantIssuance.exercise_triggers[0],
+          conversion_right: {
+            ...baseWarrantIssuance.exercise_triggers[0].conversion_right,
+            conversion_mechanism: {
+              type: 'SAFE_CONVERSION' as const,
+              conversion_discount: '0.2',
+            },
+          },
+        },
+      ],
+    };
+    expect(() => warrantIssuanceDataToDaml(input)).toThrow(OcpValidationError);
+    expect(() => warrantIssuanceDataToDaml(input)).toThrow(/Unsupported warrant conversion_mechanism type: SAFE_CONVERSION/);
   });
 
   test('warrant issuance with numeric converts_to_quantity as JS number survives round-trip', () => {

--- a/test/converters/warrantIssuanceConverters.test.ts
+++ b/test/converters/warrantIssuanceConverters.test.ts
@@ -153,7 +153,7 @@ describe('WarrantIssuance round-trip equivalence', () => {
     expect(ocfDeepEqual(dbData as Record<string, unknown>, cantonData)).toBe(true);
   });
 
-  test('rejects SAFE_CONVERSION on warrant with validation error (never emits undefined conversion_mechanism)', () => {
+  test('SAFE_CONVERSION on warrant maps to PPS-based mechanism (JSON-safe, no undefined)', () => {
     // Regression: JSON from DB may use convertible-style SAFE_CONVERSION; warrant DAML has no SAFE variant.
     // Previously the switch fell through and produced undefined → CapTableBatch.assertJsonSafe failed opaquely.
     const input = {
@@ -166,13 +166,97 @@ describe('WarrantIssuance round-trip equivalence', () => {
             conversion_mechanism: {
               type: 'SAFE_CONVERSION' as const,
               conversion_discount: '0.2',
+              conversion_valuation_cap: { amount: '10000000', currency: 'USD' },
+              conversion_mfn: true,
+              conversion_timing: 'POST_MONEY',
             },
           },
         },
       ],
     };
+    const daml = warrantIssuanceDataToDaml(input);
+    const json = JSON.stringify(daml);
+    expect(json).not.toMatch(/undefined/);
+    const mech = daml.exercise_triggers[0].conversion_right as {
+      tag: string;
+      value: { conversion_mechanism: { tag: string; value: Record<string, unknown> } };
+    };
+    expect(mech.tag).toBe('OcfRightWarrant');
+    expect(mech.value.conversion_mechanism.tag).toBe('OcfWarrantMechanismPpsBased');
+    const pps = mech.value.conversion_mechanism.value;
+    expect(pps.discount).toBe(true);
+    expect(pps.discount_percentage).toBe('0.2');
+    expect(pps.discount_amount).toBeNull();
+    expect(String(pps.description)).toContain('SAFE-style conversion');
+    expect(String(pps.description)).toContain('conversion_valuation_cap');
+  });
+
+  test('bare string SAFE_CONVERSION shorthand maps to PPS-based warrant mechanism', () => {
+    const input = {
+      ...baseWarrantIssuance,
+      exercise_triggers: [
+        {
+          ...baseWarrantIssuance.exercise_triggers[0],
+          conversion_right: {
+            ...baseWarrantIssuance.exercise_triggers[0].conversion_right,
+            conversion_mechanism: 'SAFE_CONVERSION',
+          },
+        },
+      ],
+    };
+    const daml = warrantIssuanceDataToDaml(input);
+    expect(() => JSON.stringify(daml)).not.toThrow();
+    const mech = daml.exercise_triggers[0].conversion_right as {
+      value: { conversion_mechanism: { tag: string } };
+    };
+    expect(mech.value.conversion_mechanism.tag).toBe('OcfWarrantMechanismPpsBased');
+  });
+
+  test('CONVERTIBLE_NOTE_CONVERSION on warrant maps to custom mechanism (JSON-safe)', () => {
+    const input = {
+      ...baseWarrantIssuance,
+      exercise_triggers: [
+        {
+          ...baseWarrantIssuance.exercise_triggers[0],
+          conversion_right: {
+            ...baseWarrantIssuance.exercise_triggers[0].conversion_right,
+            conversion_mechanism: {
+              type: 'CONVERTIBLE_NOTE_CONVERSION' as const,
+              conversion_discount: '0.15',
+              interest_rates: [{ rate: '0.08', accrual_start_date: '2020-01-01', accrual_end_date: null }],
+              day_count_convention: 'ACTUAL_365',
+              interest_payout: 'DEFERRED',
+            },
+          },
+        },
+      ],
+    };
+    const daml = warrantIssuanceDataToDaml(input);
+    expect(() => JSON.stringify(daml)).not.toThrow();
+    const mech = daml.exercise_triggers[0].conversion_right as {
+      value: { conversion_mechanism: { tag: string; value: { custom_conversion_description: string } } };
+    };
+    expect(mech.value.conversion_mechanism.tag).toBe('OcfWarrantMechanismCustom');
+    expect(mech.value.conversion_mechanism.value.custom_conversion_description).toContain('CONVERTIBLE_NOTE');
+  });
+
+  test('unknown conversion_mechanism type still throws (never emits undefined)', () => {
+    const input = {
+      ...baseWarrantIssuance,
+      exercise_triggers: [
+        {
+          ...baseWarrantIssuance.exercise_triggers[0],
+          conversion_right: {
+            ...baseWarrantIssuance.exercise_triggers[0].conversion_right,
+            conversion_mechanism: { type: 'NOT_A_REAL_MECHANISM' },
+          },
+        },
+      ],
+    } as Parameters<typeof warrantIssuanceDataToDaml>[0];
     expect(() => warrantIssuanceDataToDaml(input)).toThrow(OcpValidationError);
-    expect(() => warrantIssuanceDataToDaml(input)).toThrow(/Unsupported warrant conversion_mechanism type: SAFE_CONVERSION/);
+    expect(() => warrantIssuanceDataToDaml(input)).toThrow(
+      /Unsupported warrant conversion_mechanism type: NOT_A_REAL_MECHANISM/
+    );
   });
 
   test('warrant issuance with numeric converts_to_quantity as JS number survives round-trip', () => {


### PR DESCRIPTION
## Summary

OCF allows `WarrantIssuance.exercise_triggers` to carry a **generic** `conversion_right` from `ConversionTrigger`, including **StockClassConversionRight** with **RatioConversionMechanism** (`RATIO_CONVERSION`). DAML models this as `OcfAnyConversionRight` with tag **`OcfRightStockClass`**.

The SDK incorrectly treated every warrant trigger `conversion_right` as **`OcfRightWarrant`** and only built `OcfWarrantConversionMechanism`, so a schema-valid `STOCK_CLASS_CONVERSION_RIGHT` + `RATIO_CONVERSION` payload hit the warrant-only mechanism switch and failed (e.g. unknown `RATIO_CONVERSION`).

This PR **dispatches on `conversion_right.type`**: stock-class ratio rights map to **`OcfRightStockClass`** with **`OcfConversionMechanismRatioConversion`** and the generated flat fields (`ratio`, `conversion_price`, `converts_to_stock_class_id`). Absent `type` or `WARRANT_CONVERSION_RIGHT` keeps the existing **`OcfRightWarrant`** path. Readback understands **`OcfRightStockClass`** so replication round-trips stay aligned.

No data mutation or normalization shims; unsupported stock-class mechanisms or unknown `conversion_right.type` / warrant mechanism types throw **`OcpParseError` (`UNKNOWN_ENUM_VALUE`)** (or validation errors for missing required fields).

## Test plan

- `npx jest test/converters/warrantIssuanceConverters.test.ts --no-coverage`
- `npx tsc --noEmit`
- `npm run lint:fix`