### PR TITLE
feat: add factory option to OcpClient for custom deployments

### DIFF
--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -695,8 +695,7 @@ export class OcpClient {
       // ===== Authorization =====
       issuerAuthorization: {
         authorize: async (params: AuthorizeIssuerParams) => {
-          const hasPerCallOverride =
-            params.factoryContractId != null || params.factoryTemplateId != null;
+          const hasPerCallOverride = params.factoryContractId != null || params.factoryTemplateId != null;
           return authorizeIssuer(client, {
             ...params,
             ...(hasPerCallOverride

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -699,8 +699,7 @@ export class OcpClient {
       // ===== Authorization =====
       issuerAuthorization: {
         authorize: async (params: AuthorizeIssuerParams) => {
-          const hasPerCallOverride =
-            params.factoryContractId != null || params.factoryTemplateId != null;
+          const hasPerCallOverride = params.factoryContractId != null || params.factoryTemplateId != null;
           return authorizeIssuer(client, {
             ...params,
             ...(hasPerCallOverride

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -396,7 +396,8 @@ export class OcpClient {
   constructor(dependencies: OcpClientDependencies) {
     this.ledger = dependencies.ledger;
     this.validator = dependencies.validator;
-    this.factory = dependencies.factory;
+    this.factory =
+      dependencies.factory === undefined ? undefined : { ...dependencies.factory };
 
     this.OpenCapTable = this.createOpenCapTableMethods();
   }
@@ -699,7 +700,8 @@ export class OcpClient {
       // ===== Authorization =====
       issuerAuthorization: {
         authorize: async (params: AuthorizeIssuerParams) => {
-          const hasPerCallOverride = params.factoryContractId != null || params.factoryTemplateId != null;
+          const hasPerCallOverride =
+            params.factoryContractId != null || params.factoryTemplateId != null;
           return authorizeIssuer(client, {
             ...params,
             ...(hasPerCallOverride

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -352,6 +352,10 @@ export class OcpContextManager implements OcpContext {
  *
  * @example For localnet or custom factory deployments
  * ```typescript
+ * import { OcpClient } from '@open-captable-protocol/canton';
+ * import { Canton } from '@fairmint/canton-node-sdk';
+ *
+ * const canton = new Canton({ network: 'localnet' });
  * const ocp = new OcpClient({
  *   ledger: canton.ledger,
  *   factory: {
@@ -372,7 +376,7 @@ export class OcpClient {
    * Optional factory coordinates when not using the bundled mainnet/devnet config
    * (e.g. localnet, staging, or a custom network).
    */
-  public readonly factory?: { contractId: string; templateId: string };
+  public readonly factory?: OcpFactoryCoordinates;
 
   /**
    * Context manager for caching commonly used values.
@@ -695,7 +699,8 @@ export class OcpClient {
       // ===== Authorization =====
       issuerAuthorization: {
         authorize: async (params: AuthorizeIssuerParams) => {
-          const hasPerCallOverride = params.factoryContractId != null || params.factoryTemplateId != null;
+          const hasPerCallOverride =
+            params.factoryContractId != null || params.factoryTemplateId != null;
           return authorizeIssuer(client, {
             ...params,
             ...(hasPerCallOverride
@@ -722,6 +727,14 @@ export class OcpClient {
 
 // ===== Type Definitions =====
 
+/** OCP Factory contract coordinates for custom deployments (localnet, staging, etc.). */
+export interface OcpFactoryCoordinates {
+  /** Contract ID of the deployed OCP Factory */
+  contractId: string;
+  /** Template ID of the deployed OCP Factory */
+  templateId: string;
+}
+
 /**
  * Clients consumed by {@link OcpClient}.
  *
@@ -735,12 +748,7 @@ export interface OcpClientDependencies {
    * Optional factory override — use when deploying your own OCP Factory (e.g. localnet, staging, or custom network).
    * If omitted, the SDK resolves factory coords from the bundled network config.
    */
-  factory?: {
-    /** Contract ID of the deployed OCP Factory */
-    contractId: string;
-    /** Template ID of the deployed OCP Factory */
-    templateId: string;
-  };
+  readonly factory?: OcpFactoryCoordinates;
 }
 
 /** Parameters for creating a batch cap table update */

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -396,8 +396,7 @@ export class OcpClient {
   constructor(dependencies: OcpClientDependencies) {
     this.ledger = dependencies.ledger;
     this.validator = dependencies.validator;
-    this.factory =
-      dependencies.factory === undefined ? undefined : { ...dependencies.factory };
+    this.factory = dependencies.factory === undefined ? undefined : { ...dependencies.factory };
 
     this.OpenCapTable = this.createOpenCapTableMethods();
   }
@@ -700,8 +699,7 @@ export class OcpClient {
       // ===== Authorization =====
       issuerAuthorization: {
         authorize: async (params: AuthorizeIssuerParams) => {
-          const hasPerCallOverride =
-            params.factoryContractId != null || params.factoryTemplateId != null;
+          const hasPerCallOverride = params.factoryContractId != null || params.factoryTemplateId != null;
           return authorizeIssuer(client, {
             ...params,
             ...(hasPerCallOverride

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -323,7 +323,7 @@ export class OcpContextManager implements OcpContext {
  * **Namespaced APIs** (each mirrors a domain of the DAML model):
  * - {@link OcpClient.OpenCapTable} — issuer, stakeholders, stock classes, issuances, `capTable` lifecycle and batch updates
  *
- * Prefer {@link OcpClient.context} to cache FeaturedAppRight, issuer party, and cap table contract id across calls.
+ * Prefer {@link OcpClient.context} to cache issuer party and cap table contract id across calls.
  *
  * Payment-stream, coupon-minter, and related flows are not included (removed in v0.4.0); implement them with the same injected `ledger` / `validator` clients or your own modules.
  *
@@ -377,8 +377,8 @@ export class OcpClient {
   /**
    * Context manager for caching commonly used values.
    *
-   * Use this to store FeaturedAppRight details, issuer party, and cap table contract ID
-   * after fetching them once, so they can be reused across operations.
+   * Use this to store issuer party and cap table contract ID after fetching them once,
+   * so they can be reused across operations.
    */
   public readonly context: OcpContextManager = new OcpContextManager();
 
@@ -694,12 +694,19 @@ export class OcpClient {
 
       // ===== Authorization =====
       issuerAuthorization: {
-        authorize: async (params: AuthorizeIssuerParams) =>
-          authorizeIssuer(client, {
+        authorize: async (params: AuthorizeIssuerParams) => {
+          const hasPerCallOverride =
+            params.factoryContractId != null || params.factoryTemplateId != null;
+          return authorizeIssuer(client, {
             ...params,
-            factoryContractId: params.factoryContractId ?? this.factory?.contractId,
-            factoryTemplateId: params.factoryTemplateId ?? this.factory?.templateId,
-          }),
+            ...(hasPerCallOverride
+              ? {}
+              : {
+                  factoryContractId: this.factory?.contractId,
+                  factoryTemplateId: this.factory?.templateId,
+                }),
+          });
+        },
         withdraw: async (params: WithdrawAuthorizationParams) => withdrawAuthorization(client, params),
       },
 

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -40,6 +40,17 @@
  * await batch.execute();
  * ```
  *
+ * @example For localnet or custom factory deployments
+ * ```typescript
+ * const ocp = new OcpClient({
+ *   ledger: canton.ledger,
+ *   factory: {
+ *     contractId: 'YOUR_FACTORY_CONTRACT_ID',
+ *     templateId: 'YOUR_FACTORY_TEMPLATE_ID',
+ *   },
+ * });
+ * ```
+ *
  * @see https://ocp.canton.fairmint.com/ — documentation site (fairmint/web)
  *
  * @module
@@ -312,7 +323,7 @@ export class OcpContextManager implements OcpContext {
  * **Namespaced APIs** (each mirrors a domain of the DAML model):
  * - {@link OcpClient.OpenCapTable} — issuer, stakeholders, stock classes, issuances, `capTable` lifecycle and batch updates
  *
- * Prefer {@link OcpClient.context} to cache issuer party and cap table contract id across calls.
+ * Prefer {@link OcpClient.context} to cache FeaturedAppRight, issuer party, and cap table contract id across calls.
  *
  * Payment-stream, coupon-minter, and related flows are not included (removed in v0.4.0); implement them with the same injected `ledger` / `validator` clients or your own modules.
  *
@@ -338,6 +349,17 @@ export class OcpContextManager implements OcpContext {
  * batch.create('stakeholder', { id: 'sh_1', name: { legal_name: 'Example' }, ... });
  * await batch.execute();
  * ```
+ *
+ * @example For localnet or custom factory deployments
+ * ```typescript
+ * const ocp = new OcpClient({
+ *   ledger: canton.ledger,
+ *   factory: {
+ *     contractId: 'YOUR_FACTORY_CONTRACT_ID',
+ *     templateId: 'YOUR_FACTORY_TEMPLATE_ID',
+ *   },
+ * });
+ * ```
  */
 export class OcpClient {
   /** The injected Ledger JSON API client for direct ledger access */
@@ -345,6 +367,12 @@ export class OcpClient {
 
   /** Optional injected Validator API client for validator-backed workflows */
   public readonly validator?: ValidatorApiClient;
+
+  /**
+   * Optional factory coordinates when not using the bundled mainnet/devnet config
+   * (e.g. localnet, staging, or a custom network).
+   */
+  public readonly factory?: { contractId: string; templateId: string };
 
   /**
    * Context manager for caching commonly used values.
@@ -364,6 +392,7 @@ export class OcpClient {
   constructor(dependencies: OcpClientDependencies) {
     this.ledger = dependencies.ledger;
     this.validator = dependencies.validator;
+    this.factory = dependencies.factory;
 
     this.OpenCapTable = this.createOpenCapTableMethods();
   }
@@ -665,7 +694,12 @@ export class OcpClient {
 
       // ===== Authorization =====
       issuerAuthorization: {
-        authorize: async (params: AuthorizeIssuerParams) => authorizeIssuer(client, params),
+        authorize: async (params: AuthorizeIssuerParams) =>
+          authorizeIssuer(client, {
+            ...params,
+            factoryContractId: params.factoryContractId ?? this.factory?.contractId,
+            factoryTemplateId: params.factoryTemplateId ?? this.factory?.templateId,
+          }),
         withdraw: async (params: WithdrawAuthorizationParams) => withdrawAuthorization(client, params),
       },
 
@@ -691,6 +725,16 @@ export class OcpClient {
 export interface OcpClientDependencies {
   readonly ledger: LedgerJsonApiClient;
   readonly validator?: ValidatorApiClient;
+  /**
+   * Optional factory override — use when deploying your own OCP Factory (e.g. localnet, staging, or custom network).
+   * If omitted, the SDK resolves factory coords from the bundled network config.
+   */
+  factory?: {
+    /** Contract ID of the deployed OCP Factory */
+    contractId: string;
+    /** Template ID of the deployed OCP Factory */
+    templateId: string;
+  };
 }
 
 /** Parameters for creating a batch cap table update */

--- a/test/client/OcpClient.test.ts
+++ b/test/client/OcpClient.test.ts
@@ -1,11 +1,7 @@
 import type { ClientConfig } from '@fairmint/canton-node-sdk';
 import { Fairmint } from '@fairmint/open-captable-protocol-daml-js';
-import * as openCapTableCapTable from '../../src/functions/OpenCapTable/capTable';
-import {
-  authorizeIssuer,
-  type AuthorizeIssuerResult,
-} from '../../src/functions/OpenCapTable/issuerAuthorization/authorizeIssuer';
-import { OcpClient } from '../../src/OcpClient';
+import { authorizeIssuer, type AuthorizeIssuerResult } from '../../src/functions/OpenCapTable/issuerAuthorization/authorizeIssuer';
+import * as openCapTableCapTable from '../../src/functions/OpenCapTable/capTable';import { OcpClient } from '../../src/OcpClient';
 import { createLedgerAndValidatorClients, createLedgerJsonApiClient } from '../utils/cantonNodeSdkCompat';
 
 jest.mock('@fairmint/canton-node-sdk');
@@ -89,6 +85,25 @@ describe('OcpClient OpenCapTable.issuerAuthorization.authorize', () => {
       issuer: 'issuer::party',
       factoryContractId: 'per-call-cid',
       factoryTemplateId: 'per-call-tid',
+    });
+    expect(mockedAuthorizeIssuer).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mix client-level factory with a partial per-call override', async () => {
+    const ledger = createLedgerJsonApiClient(config);
+    const ocp = new OcpClient({
+      ledger,
+      factory: { contractId: 'client-factory-cid', templateId: 'client-factory-tid' },
+    });
+
+    await ocp.OpenCapTable.issuerAuthorization.authorize({
+      issuer: 'issuer::party',
+      factoryContractId: 'per-call-cid-only',
+    });
+
+    expect(mockedAuthorizeIssuer).toHaveBeenCalledWith(ledger, {
+      issuer: 'issuer::party',
+      factoryContractId: 'per-call-cid-only',
     });
     expect(mockedAuthorizeIssuer).toHaveBeenCalledTimes(1);
   });

--- a/test/client/OcpClient.test.ts
+++ b/test/client/OcpClient.test.ts
@@ -1,7 +1,10 @@
 import type { ClientConfig } from '@fairmint/canton-node-sdk';
 import { Fairmint } from '@fairmint/open-captable-protocol-daml-js';
-import { authorizeIssuer, type AuthorizeIssuerResult } from '../../src/functions/OpenCapTable/issuerAuthorization/authorizeIssuer';
 import * as openCapTableCapTable from '../../src/functions/OpenCapTable/capTable';
+import {
+  authorizeIssuer,
+  type AuthorizeIssuerResult,
+} from '../../src/functions/OpenCapTable/issuerAuthorization/authorizeIssuer';
 import { OcpClient } from '../../src/OcpClient';
 import { createLedgerAndValidatorClients, createLedgerJsonApiClient } from '../utils/cantonNodeSdkCompat';
 

--- a/test/client/OcpClient.test.ts
+++ b/test/client/OcpClient.test.ts
@@ -69,6 +69,7 @@ describe('OcpClient OpenCapTable.issuerAuthorization.authorize', () => {
       factoryContractId: 'client-factory-cid',
       factoryTemplateId: 'client-factory-tid',
     });
+    expect(mockedAuthorizeIssuer).toHaveBeenCalledTimes(1);
   });
 
   it('prefers per-call factory overrides over client-level factory', async () => {
@@ -89,6 +90,7 @@ describe('OcpClient OpenCapTable.issuerAuthorization.authorize', () => {
       factoryContractId: 'per-call-cid',
       factoryTemplateId: 'per-call-tid',
     });
+    expect(mockedAuthorizeIssuer).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/test/client/OcpClient.test.ts
+++ b/test/client/OcpClient.test.ts
@@ -1,10 +1,14 @@
 import type { ClientConfig } from '@fairmint/canton-node-sdk';
 import { Fairmint } from '@fairmint/open-captable-protocol-daml-js';
+import { authorizeIssuer, type AuthorizeIssuerResult } from '../../src/functions/OpenCapTable/issuerAuthorization/authorizeIssuer';
 import * as openCapTableCapTable from '../../src/functions/OpenCapTable/capTable';
 import { OcpClient } from '../../src/OcpClient';
 import { createLedgerAndValidatorClients, createLedgerJsonApiClient } from '../utils/cantonNodeSdkCompat';
 
 jest.mock('@fairmint/canton-node-sdk');
+jest.mock('../../src/functions/OpenCapTable/issuerAuthorization/authorizeIssuer', () => ({
+  authorizeIssuer: jest.fn(),
+}));
 
 describe('OcpClient', () => {
   const config: ClientConfig = { network: 'devnet' };
@@ -25,6 +29,63 @@ describe('OcpClient', () => {
 
     expect(ocp.ledger).toBe(ledger);
     expect(ocp.validator).toBeUndefined();
+  });
+
+  it('exposes optional client-level factory config', () => {
+    const ledger = createLedgerJsonApiClient(config);
+    const factory = { contractId: 'factory-cid', templateId: 'factory-tid' };
+
+    const ocp = new OcpClient({ ledger, factory });
+
+    expect(ocp.factory).toEqual(factory);
+  });
+});
+
+describe('OcpClient OpenCapTable.issuerAuthorization.authorize', () => {
+  const config: ClientConfig = { network: 'devnet' };
+  const minimalAuthorizeResult = {} as AuthorizeIssuerResult;
+  const mockedAuthorizeIssuer = authorizeIssuer as jest.MockedFunction<typeof authorizeIssuer>;
+
+  beforeEach(() => {
+    mockedAuthorizeIssuer.mockResolvedValue(minimalAuthorizeResult);
+  });
+
+  afterEach(() => {
+    mockedAuthorizeIssuer.mockClear();
+  });
+
+  it('merges client-level factory into authorizeIssuer when per-call overrides are omitted', async () => {
+    const ledger = createLedgerJsonApiClient(config);
+    const factory = { contractId: 'client-factory-cid', templateId: 'client-factory-tid' };
+    const ocp = new OcpClient({ ledger, factory });
+
+    await ocp.OpenCapTable.issuerAuthorization.authorize({ issuer: 'issuer::party' });
+
+    expect(mockedAuthorizeIssuer).toHaveBeenCalledWith(ledger, {
+      issuer: 'issuer::party',
+      factoryContractId: 'client-factory-cid',
+      factoryTemplateId: 'client-factory-tid',
+    });
+  });
+
+  it('prefers per-call factory overrides over client-level factory', async () => {
+    const ledger = createLedgerJsonApiClient(config);
+    const ocp = new OcpClient({
+      ledger,
+      factory: { contractId: 'client-factory-cid', templateId: 'client-factory-tid' },
+    });
+
+    await ocp.OpenCapTable.issuerAuthorization.authorize({
+      issuer: 'issuer::party',
+      factoryContractId: 'per-call-cid',
+      factoryTemplateId: 'per-call-tid',
+    });
+
+    expect(mockedAuthorizeIssuer).toHaveBeenCalledWith(ledger, {
+      issuer: 'issuer::party',
+      factoryContractId: 'per-call-cid',
+      factoryTemplateId: 'per-call-tid',
+    });
   });
 });
 

--- a/test/client/OcpClient.test.ts
+++ b/test/client/OcpClient.test.ts
@@ -1,7 +1,11 @@
 import type { ClientConfig } from '@fairmint/canton-node-sdk';
 import { Fairmint } from '@fairmint/open-captable-protocol-daml-js';
-import { authorizeIssuer, type AuthorizeIssuerResult } from '../../src/functions/OpenCapTable/issuerAuthorization/authorizeIssuer';
-import * as openCapTableCapTable from '../../src/functions/OpenCapTable/capTable';import { OcpClient } from '../../src/OcpClient';
+import * as openCapTableCapTable from '../../src/functions/OpenCapTable/capTable';
+import {
+  authorizeIssuer,
+  type AuthorizeIssuerResult,
+} from '../../src/functions/OpenCapTable/issuerAuthorization/authorizeIssuer';
+import { OcpClient } from '../../src/OcpClient';
 import { createLedgerAndValidatorClients, createLedgerJsonApiClient } from '../utils/cantonNodeSdkCompat';
 
 jest.mock('@fairmint/canton-node-sdk');


### PR DESCRIPTION
## Summary

Adds an optional `factory` field to `OcpClientDependencies` so callers can set OCP Factory contract and template IDs once at construction (localnet, staging, or custom deploys) instead of passing `factoryContractId` / `factoryTemplateId` on every `authorize()` call.

## Behavior

- **Priority:** per-call `AuthorizeIssuerParams` → client-level `factory` → bundled JSON (`ocp-factory-contract-id.json`) via ledger network.
- `OcpClient.factory` is exposed as read-only for introspection.
- JSDoc examples updated at module and class level.

## Tests

- Unit tests mock `authorizeIssuer` and assert merged params for client-level factory and per-call override precedence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `issuerAuthorization.authorize` resolves factory coordinates, which can alter authorization behavior on non-standard networks if misconfigured. Scope is limited to one call path and covered by focused unit tests.
> 
> **Overview**
> Adds an optional `factory` configuration to `OcpClient`/`OcpClientDependencies` (contract + template IDs) to support localnet/staging/custom deployments and exposes it as `ocp.factory`.
> 
> Updates `OpenCapTable.issuerAuthorization.authorize` to automatically pass the client-level factory coordinates to `authorizeIssuer` *only when* the call doesn’t already provide `factoryContractId`/`factoryTemplateId`, and documents the new usage via JSDoc examples.
> 
> Extends unit tests to mock `authorizeIssuer` and verify precedence rules (per-call overrides win; partial overrides do not mix with client defaults) plus the new `factory` property exposure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd16372211d9b1a618d96b7383ae6b44b026447e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional client-level factory configuration to streamline issuer authorization
  * Issuer authorization now defaults to client-level factory values, with per-call overrides respected

* **Documentation**
  * Added examples and guidance for factory-based client configuration and context wording

* **Tests**
  * Added tests covering client-level factory behavior and authorization flow with overrides
<!-- end of auto-generated comment: release notes by coderabbit.ai -->