### PR TITLE
feat: public createFactory API for OcpFactory

### DIFF
--- a/src/functions/OpenCapTable/factory/createFactory.ts
+++ b/src/functions/OpenCapTable/factory/createFactory.ts
@@ -1,10 +1,7 @@
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
-import {
-  findCreatedEventByTemplateId,
-  type SubmitAndWaitForTransactionTreeResponse,
-} from '../../../types/common';
 import { OCP_TEMPLATES, type Fairmint } from '@fairmint/open-captable-protocol-daml-js';
 import { OcpContractError, OcpErrorCodes } from '../../../errors';
+import { findCreatedEventByTemplateId } from '../../../types/common';
 
 export interface CreateFactoryParams {
   /** Party ID that will own the factory (submits the create as this party). */
@@ -35,7 +32,7 @@ export async function createFactory(
     system_operator: params.systemOperator,
   };
 
-  const response = (await client.submitAndWaitForTransactionTree({
+  const response = await client.submitAndWaitForTransactionTree({
     commands: [
       {
         CreateCommand: {
@@ -45,7 +42,7 @@ export async function createFactory(
       },
     ],
     actAs: [params.systemOperator],
-  })) as SubmitAndWaitForTransactionTreeResponse;
+  });
 
   const created = findCreatedEventByTemplateId(response, templateId);
   if (!created) {

--- a/src/functions/OpenCapTable/factory/createFactory.ts
+++ b/src/functions/OpenCapTable/factory/createFactory.ts
@@ -1,5 +1,8 @@
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
-import { findCreatedEventByTemplateId } from '@fairmint/canton-node-sdk/build/src/utils/contracts/findCreatedEvent';
+import {
+  findCreatedEventByTemplateId,
+  type SubmitAndWaitForTransactionTreeResponse,
+} from '../../../types/common';
 import { OCP_TEMPLATES, type Fairmint } from '@fairmint/open-captable-protocol-daml-js';
 import { OcpContractError, OcpErrorCodes } from '../../../errors';
 
@@ -32,7 +35,7 @@ export async function createFactory(
     system_operator: params.systemOperator,
   };
 
-  const response = await client.submitAndWaitForTransactionTree({
+  const response = (await client.submitAndWaitForTransactionTree({
     commands: [
       {
         CreateCommand: {
@@ -42,7 +45,7 @@ export async function createFactory(
       },
     ],
     actAs: [params.systemOperator],
-  });
+  })) as SubmitAndWaitForTransactionTreeResponse;
 
   const created = findCreatedEventByTemplateId(response, templateId);
   if (!created) {

--- a/src/functions/OpenCapTable/factory/createFactory.ts
+++ b/src/functions/OpenCapTable/factory/createFactory.ts
@@ -1,5 +1,4 @@
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
-import type { SubmitAndWaitForTransactionTreeResponse } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/operations';
 import { findCreatedEventByTemplateId } from '@fairmint/canton-node-sdk/build/src/utils/contracts/findCreatedEvent';
 import { OCP_TEMPLATES, type Fairmint } from '@fairmint/open-captable-protocol-daml-js';
 import { OcpContractError, OcpErrorCodes } from '../../../errors';
@@ -38,7 +37,7 @@ export async function createFactory(
     system_operator: params.systemOperator,
   };
 
-  const response = (await client.submitAndWaitForTransactionTree({
+  const response = await client.submitAndWaitForTransactionTree({
     commands: [
       {
         CreateCommand: {
@@ -48,7 +47,7 @@ export async function createFactory(
       },
     ],
     actAs: [params.systemOperator],
-  })) as SubmitAndWaitForTransactionTreeResponse;
+  });
 
   const created = findCreatedEventByTemplateId(response, templateId);
   if (!created) {

--- a/src/functions/OpenCapTable/factory/createFactory.ts
+++ b/src/functions/OpenCapTable/factory/createFactory.ts
@@ -1,11 +1,17 @@
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
+import type { SubmitAndWaitForTransactionTreeResponse } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/operations';
+import { findCreatedEventByTemplateId } from '@fairmint/canton-node-sdk/build/src/utils/contracts/findCreatedEvent';
 import { OCP_TEMPLATES, type Fairmint } from '@fairmint/open-captable-protocol-daml-js';
 import { OcpContractError, OcpErrorCodes } from '../../../errors';
-import { findCreatedEventByTemplateId } from '../../../types/common';
 
 export interface CreateFactoryParams {
   /** Party ID that will own the factory (submits the create as this party). */
   systemOperator: string;
+  /**
+   * Override when your ledger uses a different `OcpFactory` template id than this SDK's
+   * bundled default (`OCP_TEMPLATES.ocpFactory`).
+   */
+  templateId?: string;
 }
 
 export interface CreateFactoryResult {
@@ -27,12 +33,12 @@ export async function createFactory(
   client: LedgerJsonApiClient,
   params: CreateFactoryParams
 ): Promise<CreateFactoryResult> {
-  const templateId = OCP_TEMPLATES.ocpFactory;
+  const templateId = params.templateId ?? OCP_TEMPLATES.ocpFactory;
   const createArguments: Fairmint.OpenCapTable.OcpFactory.OcpFactory = {
     system_operator: params.systemOperator,
   };
 
-  const response = await client.submitAndWaitForTransactionTree({
+  const response = (await client.submitAndWaitForTransactionTree({
     commands: [
       {
         CreateCommand: {
@@ -42,7 +48,7 @@ export async function createFactory(
       },
     ],
     actAs: [params.systemOperator],
-  });
+  })) as SubmitAndWaitForTransactionTreeResponse;
 
   const created = findCreatedEventByTemplateId(response, templateId);
   if (!created) {

--- a/src/functions/OpenCapTable/factory/createFactory.ts
+++ b/src/functions/OpenCapTable/factory/createFactory.ts
@@ -1,5 +1,4 @@
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
-import type { SubmitAndWaitForTransactionTreeResponse } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/operations';
 import { findCreatedEventByTemplateId } from '@fairmint/canton-node-sdk/build/src/utils/contracts/findCreatedEvent';
 import { OCP_TEMPLATES, type Fairmint } from '@fairmint/open-captable-protocol-daml-js';
 import { OcpContractError, OcpErrorCodes } from '../../../errors';
@@ -33,7 +32,7 @@ export async function createFactory(
     system_operator: params.systemOperator,
   };
 
-  const response = (await client.submitAndWaitForTransactionTree({
+  const response = await client.submitAndWaitForTransactionTree({
     commands: [
       {
         CreateCommand: {
@@ -43,7 +42,7 @@ export async function createFactory(
       },
     ],
     actAs: [params.systemOperator],
-  })) as SubmitAndWaitForTransactionTreeResponse;
+  });
 
   const created = findCreatedEventByTemplateId(response, templateId);
   if (!created) {

--- a/src/functions/OpenCapTable/factory/createFactory.ts
+++ b/src/functions/OpenCapTable/factory/createFactory.ts
@@ -1,0 +1,63 @@
+import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
+import type { SubmitAndWaitForTransactionTreeResponse } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/operations';
+import { findCreatedEventByTemplateId } from '@fairmint/canton-node-sdk/build/src/utils/contracts/findCreatedEvent';
+import { OCP_TEMPLATES, type Fairmint } from '@fairmint/open-captable-protocol-daml-js';
+import { OcpContractError, OcpErrorCodes } from '../../../errors';
+
+export interface CreateFactoryParams {
+  /** Party ID that will own the factory (submits the create as this party). */
+  systemOperator: string;
+}
+
+export interface CreateFactoryResult {
+  contractId: string;
+  templateId: string;
+  updateId: string;
+}
+
+/**
+ * Deploy a new OCP Factory contract on the ledger.
+ *
+ * Use this when setting up a custom Canton network (localnet, staging, or any deployment
+ * that is not mainnet or devnet). After creating the factory, pass the result as
+ * `factory` to `new OcpClient({ ledger, factory: result })`.
+ *
+ * On mainnet and devnet the factory is already deployed — you do not need to call this.
+ */
+export async function createFactory(
+  client: LedgerJsonApiClient,
+  params: CreateFactoryParams
+): Promise<CreateFactoryResult> {
+  const templateId = OCP_TEMPLATES.ocpFactory;
+  const createArguments: Fairmint.OpenCapTable.OcpFactory.OcpFactory = {
+    system_operator: params.systemOperator,
+  };
+
+  const response = (await client.submitAndWaitForTransactionTree({
+    commands: [
+      {
+        CreateCommand: {
+          templateId,
+          createArguments,
+        },
+      },
+    ],
+    actAs: [params.systemOperator],
+  })) as SubmitAndWaitForTransactionTreeResponse;
+
+  const created = findCreatedEventByTemplateId(response, templateId);
+  if (!created) {
+    throw new OcpContractError('Expected CreatedTreeEvent not found for OcpFactory', {
+      templateId,
+      code: OcpErrorCodes.RESULT_NOT_FOUND,
+    });
+  }
+
+  const { contractId: createdContractId, templateId: createdTemplateId } = created.CreatedTreeEvent.value;
+
+  return {
+    contractId: createdContractId,
+    templateId: createdTemplateId,
+    updateId: response.transactionTree.updateId,
+  };
+}

--- a/src/functions/OpenCapTable/factory/index.ts
+++ b/src/functions/OpenCapTable/factory/index.ts
@@ -1,0 +1,1 @@
+export * from './createFactory';

--- a/src/functions/OpenCapTable/index.ts
+++ b/src/functions/OpenCapTable/index.ts
@@ -14,6 +14,7 @@ export * from './equityCompensationRelease';
 export * from './equityCompensationRepricing';
 export * from './equityCompensationRetraction';
 export * from './equityCompensationTransfer';
+export * from './factory';
 export * from './issuer';
 export * from './issuerAuthorization';
 export * from './issuerAuthorizedSharesAdjustment';

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -22,6 +22,8 @@ export type { ClientConfig, LedgerJsonApiClient, ValidatorApiClient } from '@fai
 
 export type { SubmitAndWaitForTransactionTreeResponse } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/operations';
 
+export { findCreatedEventByTemplateId } from '@fairmint/canton-node-sdk/build/src/utils/contracts/findCreatedEvent';
+
 // ===== Common Params Types =====
 
 /**

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -22,8 +22,6 @@ export type { ClientConfig, LedgerJsonApiClient, ValidatorApiClient } from '@fai
 
 export type { SubmitAndWaitForTransactionTreeResponse } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/operations';
 
-export { findCreatedEventByTemplateId } from '@fairmint/canton-node-sdk/build/src/utils/contracts/findCreatedEvent';
-
 // ===== Common Params Types =====
 
 /**

--- a/test/functions/factory/createFactory.test.ts
+++ b/test/functions/factory/createFactory.test.ts
@@ -1,7 +1,7 @@
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
-import type { SubmitAndWaitForTransactionTreeResponse } from '../../../src/types/common';
 import { OCP_TEMPLATES } from '@fairmint/open-captable-protocol-daml-js';
 import { createFactory } from '../../../src/functions/OpenCapTable/factory/createFactory';
+import type { SubmitAndWaitForTransactionTreeResponse } from '../../../src/types/common';
 
 describe('createFactory', () => {
   let mockClient: jest.Mocked<Pick<LedgerJsonApiClient, 'submitAndWaitForTransactionTree'>>;
@@ -72,7 +72,7 @@ describe('createFactory', () => {
         synchronizerId: 'sync-1',
         recordTime: '2026-02-17T00:00:00Z',
       },
-    } as unknown as SubmitAndWaitForTransactionTreeResponse);
+    });
 
     await expect(createFactory(mockClient as unknown as LedgerJsonApiClient, { systemOperator })).rejects.toThrow(
       'Expected CreatedTreeEvent not found for OcpFactory'

--- a/test/functions/factory/createFactory.test.ts
+++ b/test/functions/factory/createFactory.test.ts
@@ -1,7 +1,6 @@
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
-import type { SubmitAndWaitForTransactionTreeResponse } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/operations';
+import type { SubmitAndWaitForTransactionTreeResponse } from '../../../src/types/common';
 import { OCP_TEMPLATES } from '@fairmint/open-captable-protocol-daml-js';
-import { OcpContractError } from '../../../src/errors';
 import { createFactory } from '../../../src/functions/OpenCapTable/factory/createFactory';
 
 describe('createFactory', () => {
@@ -73,10 +72,10 @@ describe('createFactory', () => {
         synchronizerId: 'sync-1',
         recordTime: '2026-02-17T00:00:00Z',
       },
-    });
+    } as unknown as SubmitAndWaitForTransactionTreeResponse);
 
     await expect(createFactory(mockClient as unknown as LedgerJsonApiClient, { systemOperator })).rejects.toThrow(
-      OcpContractError
+      'Expected CreatedTreeEvent not found for OcpFactory'
     );
   });
 });

--- a/test/functions/factory/createFactory.test.ts
+++ b/test/functions/factory/createFactory.test.ts
@@ -1,0 +1,82 @@
+import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
+import type { SubmitAndWaitForTransactionTreeResponse } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/operations';
+import { OCP_TEMPLATES } from '@fairmint/open-captable-protocol-daml-js';
+import { OcpContractError } from '../../../src/errors';
+import { createFactory } from '../../../src/functions/OpenCapTable/factory/createFactory';
+
+describe('createFactory', () => {
+  let mockClient: jest.Mocked<Pick<LedgerJsonApiClient, 'submitAndWaitForTransactionTree'>>;
+
+  const systemOperator = 'system-operator::1220deadbeef';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient = {
+      submitAndWaitForTransactionTree: jest.fn(),
+    };
+  });
+
+  it('returns contractId, templateId, and updateId on success', async () => {
+    const factoryTemplateId = OCP_TEMPLATES.ocpFactory;
+    const mockContractId = 'factory-contract-cid';
+    const mockUpdateId = 'update-abc';
+
+    mockClient.submitAndWaitForTransactionTree.mockResolvedValue({
+      transactionTree: {
+        updateId: mockUpdateId,
+        commandId: 'cmd-1',
+        workflowId: '',
+        offset: 1,
+        eventsById: {
+          e1: {
+            CreatedTreeEvent: {
+              value: {
+                templateId: factoryTemplateId,
+                contractId: mockContractId,
+              },
+            },
+          },
+        },
+        synchronizerId: 'sync-1',
+        recordTime: '2026-02-17T00:00:00Z',
+      },
+    } as unknown as SubmitAndWaitForTransactionTreeResponse);
+
+    const result = await createFactory(mockClient as unknown as LedgerJsonApiClient, { systemOperator });
+
+    expect(result).toEqual({
+      contractId: mockContractId,
+      templateId: factoryTemplateId,
+      updateId: mockUpdateId,
+    });
+    expect(mockClient.submitAndWaitForTransactionTree).toHaveBeenCalledWith({
+      commands: [
+        {
+          CreateCommand: {
+            templateId: factoryTemplateId,
+            createArguments: { system_operator: systemOperator },
+          },
+        },
+      ],
+      actAs: [systemOperator],
+    });
+  });
+
+  it('throws OcpContractError when CreatedTreeEvent is missing', async () => {
+    mockClient.submitAndWaitForTransactionTree.mockResolvedValue({
+      transactionTree: {
+        updateId: 'update-x',
+        commandId: 'cmd-empty',
+        workflowId: '',
+        offset: 1,
+        eventsById: {},
+        synchronizerId: 'sync-1',
+        recordTime: '2026-02-17T00:00:00Z',
+      },
+    } as unknown as SubmitAndWaitForTransactionTreeResponse);
+
+    await expect(createFactory(mockClient as unknown as LedgerJsonApiClient, { systemOperator })).rejects.toThrow(
+      OcpContractError
+    );
+  });
+});

--- a/test/functions/factory/createFactory.test.ts
+++ b/test/functions/factory/createFactory.test.ts
@@ -73,7 +73,7 @@ describe('createFactory', () => {
         synchronizerId: 'sync-1',
         recordTime: '2026-02-17T00:00:00Z',
       },
-    } as unknown as SubmitAndWaitForTransactionTreeResponse);
+    });
 
     await expect(createFactory(mockClient as unknown as LedgerJsonApiClient, { systemOperator })).rejects.toThrow(
       OcpContractError

--- a/test/functions/factory/createFactory.test.ts
+++ b/test/functions/factory/createFactory.test.ts
@@ -61,6 +61,51 @@ describe('createFactory', () => {
     });
   });
 
+  it('uses params.templateId when provided', async () => {
+    const customTemplateId = 'custom::pkg::OcpFactory';
+    const mockContractId = 'factory-contract-cid';
+    const mockUpdateId = 'update-xyz';
+
+    mockClient.submitAndWaitForTransactionTree.mockResolvedValue({
+      transactionTree: {
+        updateId: mockUpdateId,
+        commandId: 'cmd-2',
+        workflowId: '',
+        offset: 1,
+        eventsById: {
+          e1: {
+            CreatedTreeEvent: {
+              value: {
+                templateId: customTemplateId,
+                contractId: mockContractId,
+              },
+            },
+          },
+        },
+        synchronizerId: 'sync-1',
+        recordTime: '2026-02-17T00:00:00Z',
+      },
+    } as unknown as SubmitAndWaitForTransactionTreeResponse);
+
+    const result = await createFactory(mockClient as unknown as LedgerJsonApiClient, {
+      systemOperator,
+      templateId: customTemplateId,
+    });
+
+    expect(result.templateId).toBe(customTemplateId);
+    expect(mockClient.submitAndWaitForTransactionTree).toHaveBeenCalledWith({
+      commands: [
+        {
+          CreateCommand: {
+            templateId: customTemplateId,
+            createArguments: { system_operator: systemOperator },
+          },
+        },
+      ],
+      actAs: [systemOperator],
+    });
+  });
+
   it('throws OcpContractError when CreatedTreeEvent is missing', async () => {
     mockClient.submitAndWaitForTransactionTree.mockResolvedValue({
       transactionTree: {


### PR DESCRIPTION
## Summary
Adds `createFactory(client, { systemOperator })` to deploy `Fairmint.OpenCapTable.OcpFactory:OcpFactory` on custom Canton networks (localnet, staging, etc.). Returns `contractId`, `templateId`, and `updateId`; throws `OcpContractError` when the expected Created event is missing.

## Usage
After creating the factory, pass the result as `factory` to `new OcpClient({ ledger, factory: result })`.

Mainnet/devnet factory deployments are unchanged — callers do not need this there.

## Testing
- `npm run typecheck`
- `npx jest test/functions/factory/createFactory.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive ledger-write API that creates an `OcpFactory` contract and relies on parsing transaction tree events; misconfiguration of `templateId` or event-shape differences could surface as runtime errors but existing flows are otherwise unchanged.
> 
> **Overview**
> Adds a new public `createFactory(client, { systemOperator, templateId? })` helper to deploy an `OcpFactory` contract on custom Canton networks by submitting a `CreateCommand`, then extracting the resulting `CreatedTreeEvent` and returning `{ contractId, templateId, updateId }` (or throwing `OcpContractError` if the create event is missing).
> 
> Exports the new `factory` module from `OpenCapTable`, and adds Jest coverage for success, custom `templateId`, and missing-created-event error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c63d0af15fc5630f21bde27265cc9669c22edf13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to deploy OCP Factory contracts on a Canton ledger with contract identification details returned upon successful creation.

* **Tests**
  * Added test coverage for factory creation, validating successful deployment and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->