### PR TITLE
docs: use plain strings in JSDoc examples — toPartyId/toContractId are optional helpers

### DIFF
--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -12,7 +12,7 @@
  *
  * @example
  * ```typescript
- * import { OcpClient, toContractId, toPartyId } from '@open-captable-protocol/canton';
+ * import { OcpClient } from '@open-captable-protocol/canton';
  * import { Canton } from '@fairmint/canton-node-sdk';
  *
  * const canton = new Canton({ network: 'localnet' });
@@ -26,15 +26,15 @@
  *
  * // Read operations return ContractResult<T> with { data, contractId }
  * const { data: issuer } = await ocp.OpenCapTable.issuer.get({
- *   contractId: toContractId('00abc123'),
+ *   contractId: '00abc123',
  * });
  * console.log(issuer.object_type); // 'ISSUER'
  * console.log(issuer.legal_name);
  *
  * // Batch updates
  * const batch = ocp.OpenCapTable.capTable.update({
- *   capTableContractId: toContractId('...'),
- *   actAs: [toPartyId('issuer::namespace')],
+ *   capTableContractId: 'REPLACE_WITH_CAP_TABLE_CONTRACT_ID',
+ *   actAs: ['issuer::namespace'],
  * });
  * batch.create('stakeholder', stakeholderData);
  * await batch.execute();
@@ -329,7 +329,7 @@ export class OcpContextManager implements OcpContext {
  *
  * @example Wire client, read issuer, batch cap table update
  * ```typescript
- * import { OcpClient, toContractId, toPartyId } from '@open-captable-protocol/canton';
+ * import { OcpClient } from '@open-captable-protocol/canton';
  * import { Canton } from '@fairmint/canton-node-sdk';
  *
  * const canton = new Canton({ network: 'localnet' });
@@ -339,12 +339,12 @@ export class OcpContextManager implements OcpContext {
  * });
  *
  * const { data: issuer } = await ocp.OpenCapTable.issuer.get({
- *   contractId: toContractId('00abc123'),
+ *   contractId: '00abc123',
  * });
  *
  * const batch = ocp.OpenCapTable.capTable.update({
- *   capTableContractId: toContractId('...'),
- *   actAs: [toPartyId('issuer::namespace')],
+ *   capTableContractId: 'REPLACE_WITH_CAP_TABLE_CONTRACT_ID',
+ *   actAs: ['issuer::namespace'],
  * });
  * batch.create('stakeholder', { id: 'sh_1', name: { legal_name: 'Example' }, ... });
  * await batch.execute();


### PR DESCRIPTION
## Summary

Aligns `OcpClient.ts` module-level and class-level `@example` JSDoc with the public API: party and contract IDs are accepted as plain `string`; `toPartyId` / `toContractId` remain optional branded helpers.

## Changes
- Import only `OcpClient` in examples
- Use string literals for `contractId`, `capTableContractId`, and `actAs` entries

## Checks
- `npm run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates JSDoc example code to reflect accepted `string` IDs; no runtime logic or types are changed.
> 
> **Overview**
> Updates `src/OcpClient.ts` module/class `@example` snippets to use plain `string` values for `contractId`, `capTableContractId`, and `actAs`, and removes `toContractId`/`toPartyId` from the example imports to match the public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4aa4d37b86f221ef7d3233d5eb18d6574d8672f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples in OcpClient documentation to use simplified contract ID and party ID patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->