### PR TITLE
Refactor OCF entity metadata registry

### DIFF
--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -216,8 +216,8 @@ function makeGenericEntityReader<T>(
   entityType: Parameters<typeof getEntityAsOcf>[1]
 ): EntityReader<T> {
   return {
-    get: async (params) => {
-      const r = await getEntityAsOcf(client, entityType, params.contractId, params);
+    get: async ({ contractId, ...options }) => {
+      const r = await getEntityAsOcf(client, entityType, contractId, options);
       return toContractResult<T>(withObjectType(r.data, ENTITY_OBJECT_TYPE_MAP[entityType]), r.contractId);
     },
   };

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -112,6 +112,7 @@ import {
   type WithdrawAuthorizationResult,
 } from './functions';
 import {
+  ENTITY_OBJECT_TYPE_MAP,
   archiveCapTable,
   CapTableBatch,
   classifyIssuerCapTables,
@@ -201,6 +202,15 @@ function toContractResult<T>(data: unknown, contractId: string): ContractResult<
   return { data: data as T, contractId };
 }
 
+function withObjectType(data: unknown, objectType: string): unknown {
+  if (data == null || typeof data !== 'object' || Array.isArray(data)) {
+    return data;
+  }
+
+  const record = data as Record<string, unknown>;
+  return typeof record.object_type === 'string' ? record : { ...record, object_type: objectType };
+}
+
 function makeGenericEntityReader<T>(
   client: LedgerJsonApiClient,
   entityType: Parameters<typeof getEntityAsOcf>[1]
@@ -208,7 +218,7 @@ function makeGenericEntityReader<T>(
   return {
     get: async (params) => {
       const r = await getEntityAsOcf(client, entityType, params.contractId, params);
-      return toContractResult<T>(r.data, r.contractId);
+      return toContractResult<T>(withObjectType(r.data, ENTITY_OBJECT_TYPE_MAP[entityType]), r.contractId);
     },
   };
 }

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -68,6 +68,7 @@ import {
   getConvertibleIssuanceAsOcf,
   getConvertibleTransferAsOcf,
   getDocumentAsOcf,
+  getEntityAsOcf,
   getEquityCompensationAcceptanceAsOcf,
   getEquityCompensationCancellationAsOcf,
   getEquityCompensationExerciseAsOcf,
@@ -127,12 +128,16 @@ import type {
   OcfConvertibleCancellationOutput,
   OcfConvertibleConversionOutput,
   OcfConvertibleIssuanceOutput,
+  OcfConvertibleRetractionOutput,
   OcfConvertibleTransferOutput,
   OcfDocumentOutput,
   OcfEquityCompensationAcceptanceOutput,
   OcfEquityCompensationCancellationOutput,
   OcfEquityCompensationExerciseOutput,
   OcfEquityCompensationIssuanceOutput,
+  OcfEquityCompensationReleaseOutput,
+  OcfEquityCompensationRepricingOutput,
+  OcfEquityCompensationRetractionOutput,
   OcfEquityCompensationTransferOutput,
   OcfIssuerAuthorizedSharesAdjustmentOutput,
   OcfIssuerOutput,
@@ -151,8 +156,10 @@ import type {
   OcfStockLegendTemplateOutput,
   OcfStockPlanOutput,
   OcfStockPlanPoolAdjustmentOutput,
+  OcfStockPlanReturnToPoolOutput,
   OcfStockReissuanceOutput,
   OcfStockRepurchaseOutput,
+  OcfStockRetractionOutput,
   OcfStockTransferOutput,
   OcfValuationOutput,
   OcfVestingAccelerationOutput,
@@ -163,6 +170,7 @@ import type {
   OcfWarrantCancellationOutput,
   OcfWarrantExerciseOutput,
   OcfWarrantIssuanceOutput,
+  OcfWarrantRetractionOutput,
   OcfWarrantTransferOutput,
 } from './types/output';
 
@@ -191,6 +199,18 @@ function toContractResult<T>(data: unknown, contractId: string): ContractResult<
     );
   }
   return { data: data as T, contractId };
+}
+
+function makeGenericEntityReader<T>(
+  client: LedgerJsonApiClient,
+  entityType: Parameters<typeof getEntityAsOcf>[1]
+): EntityReader<T> {
+  return {
+    get: async (params) => {
+      const r = await getEntityAsOcf(client, entityType, params.contractId, params);
+      return toContractResult<T>(r.data, r.contractId);
+    },
+  };
 }
 
 // ===== Context Manager =====
@@ -429,6 +449,9 @@ export class OcpClient {
 
   private createOpenCapTableMethods(): OpenCapTableMethods {
     const client = this.ledger;
+    const genericEntity = <T>(entityType: Parameters<typeof getEntityAsOcf>[1]): EntityReader<T> =>
+      makeGenericEntityReader<T>(client, entityType);
+
     return {
       // ===== Objects =====
       issuer: {
@@ -556,6 +579,13 @@ export class OcpClient {
         },
       },
 
+      // ===== Retractions =====
+      stockRetraction: genericEntity<OcfStockRetractionOutput>('stockRetraction'),
+      warrantRetraction: genericEntity<OcfWarrantRetractionOutput>('warrantRetraction'),
+      convertibleRetraction: genericEntity<OcfConvertibleRetractionOutput>('convertibleRetraction'),
+      equityCompensationRetraction:
+        genericEntity<OcfEquityCompensationRetractionOutput>('equityCompensationRetraction'),
+
       // ===== Exercises =====
       equityCompensationExercise: {
         get: async (params) => {
@@ -641,6 +671,7 @@ export class OcpClient {
           return toContractResult(r.event, r.contractId);
         },
       },
+      stockPlanReturnToPool: genericEntity<OcfStockPlanReturnToPoolOutput>('stockPlanReturnToPool'),
 
       // ===== Other Transactions =====
       stockRepurchase: {
@@ -661,6 +692,8 @@ export class OcpClient {
           return toContractResult(r.event, r.contractId);
         },
       },
+      equityCompensationRelease: genericEntity<OcfEquityCompensationReleaseOutput>('equityCompensationRelease'),
+      equityCompensationRepricing: genericEntity<OcfEquityCompensationRepricingOutput>('equityCompensationRepricing'),
 
       // ===== Vesting =====
       vestingStart: {
@@ -756,6 +789,8 @@ interface CapTableUpdateParams {
   capTableContractId: string;
   /** Optional contract details for the CapTable (used to get correct templateId from ledger) */
   capTableContractDetails?: { templateId: string };
+  /** Optional deterministic command ID for idempotent retry handling. */
+  commandId?: string;
   /** Party IDs to act as (signatories) */
   actAs: string[];
   /** Optional additional party IDs for read access */
@@ -807,6 +842,12 @@ interface OpenCapTableMethods {
   convertibleCancellation: EntityReader<OcfConvertibleCancellationOutput>;
   equityCompensationCancellation: EntityReader<OcfEquityCompensationCancellationOutput>;
 
+  // Retractions
+  stockRetraction: EntityReader<OcfStockRetractionOutput>;
+  warrantRetraction: EntityReader<OcfWarrantRetractionOutput>;
+  convertibleRetraction: EntityReader<OcfConvertibleRetractionOutput>;
+  equityCompensationRetraction: EntityReader<OcfEquityCompensationRetractionOutput>;
+
   // Exercises
   equityCompensationExercise: EntityReader<OcfEquityCompensationExerciseOutput>;
   warrantExercise: EntityReader<OcfWarrantExerciseOutput>;
@@ -827,11 +868,14 @@ interface OpenCapTableMethods {
   stockClassConversionRatioAdjustment: EntityReader<OcfStockClassConversionRatioAdjustmentOutput>;
   stockClassSplit: EntityReader<OcfStockClassSplitOutput>;
   stockPlanPoolAdjustment: EntityReader<OcfStockPlanPoolAdjustmentOutput>;
+  stockPlanReturnToPool: EntityReader<OcfStockPlanReturnToPoolOutput>;
 
   // Other transactions
   stockRepurchase: EntityReader<OcfStockRepurchaseOutput>;
   stockConsolidation: EntityReader<OcfStockConsolidationOutput>;
   stockReissuance: EntityReader<OcfStockReissuanceOutput>;
+  equityCompensationRelease: EntityReader<OcfEquityCompensationReleaseOutput>;
+  equityCompensationRepricing: EntityReader<OcfEquityCompensationRepricingOutput>;
 
   // Vesting
   vestingStart: EntityReader<OcfVestingStartOutput>;

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -112,10 +112,10 @@ import {
   type WithdrawAuthorizationResult,
 } from './functions';
 import {
-  ENTITY_OBJECT_TYPE_MAP,
   archiveCapTable,
   CapTableBatch,
   classifyIssuerCapTables,
+  ENTITY_OBJECT_TYPE_MAP,
   getCapTableState,
   type ArchiveCapTableParams,
   type ArchiveCapTableResult,

--- a/src/functions/OpenCapTable/capTable/CapTableBatch.ts
+++ b/src/functions/OpenCapTable/capTable/CapTableBatch.ts
@@ -28,10 +28,16 @@ export interface CapTableBatchParams {
   capTableContractId: string;
   /** Optional contract details for the CapTable (used to get correct templateId from ledger) */
   capTableContractDetails?: { templateId: string };
+  /** Optional deterministic command ID for callers that need idempotent retry semantics. */
+  commandId?: string;
   /** Party IDs to act as (signatories) */
   actAs: string[];
   /** Optional additional party IDs for read access */
   readAs?: string[];
+}
+
+function createUpdateCapTableCommandId(): string {
+  return `update-captable-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
 /** Metadata for a batch operation item, used for debugging and error reporting. */
@@ -240,7 +246,7 @@ export class CapTableBatch {
     try {
       response = await this.client.submitAndWaitForTransactionTree({
         commands: [command],
-        commandId: `update-captable-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+        commandId: this.params.commandId ?? createUpdateCapTableCommandId(),
         actAs: this.params.actAs,
         readAs: this.params.readAs,
         disclosedContracts,

--- a/src/functions/OpenCapTable/capTable/batchTypes.ts
+++ b/src/functions/OpenCapTable/capTable/batchTypes.ts
@@ -218,291 +218,427 @@ export interface OcfEntityDataMap {
 /** Helper type to get the native OCF data type for a given entity type. */
 export type OcfDataTypeFor<T extends OcfEntityType> = OcfEntityDataMap[T];
 
+/** Shared registry entry for all OCF entity metadata used by batch, read, schema, and state code. */
+export interface OcfEntityRegistryEntry {
+  /** Canonical OCF object_type accepted by schema validation. */
+  objectType: string;
+  /** Field containing entity data in DAML contract create arguments. */
+  dataField: string;
+  /** Alternate create-argument fields accepted for older template payloads. */
+  dataFieldFallbacks?: readonly string[];
+  /** CapTable map field that stores object-id to contract-id entries. */
+  capTableField?: string;
+  /** CapTable map field that stores security-id uniqueness entries. */
+  securityIdField?: string;
+  /** DAML union suffix used to derive `OcfCreateX`, `OcfEditX`, and `OcfDeleteX` tags. */
+  batchName: string;
+  /** False for edit-only entities such as issuer. */
+  supportsCreate?: boolean;
+  /** False for non-deletable entities such as issuer. */
+  supportsDelete?: boolean;
+}
+
+/**
+ * Single source of truth for entity-level metadata.
+ *
+ * PlanSecurity entries intentionally use EquityCompensation object types and batch tags because the SDK normalizes
+ * those aliases before writing to Canton.
+ */
+export const ENTITY_REGISTRY = {
+  convertibleAcceptance: {
+    objectType: 'TX_CONVERTIBLE_ACCEPTANCE',
+    dataField: 'acceptance_data',
+    capTableField: 'convertible_acceptances',
+    batchName: 'ConvertibleAcceptance',
+  },
+  convertibleCancellation: {
+    objectType: 'TX_CONVERTIBLE_CANCELLATION',
+    dataField: 'cancellation_data',
+    capTableField: 'convertible_cancellations',
+    batchName: 'ConvertibleCancellation',
+  },
+  convertibleConversion: {
+    objectType: 'TX_CONVERTIBLE_CONVERSION',
+    dataField: 'conversion_data',
+    capTableField: 'convertible_conversions',
+    batchName: 'ConvertibleConversion',
+  },
+  convertibleIssuance: {
+    objectType: 'TX_CONVERTIBLE_ISSUANCE',
+    dataField: 'issuance_data',
+    capTableField: 'convertible_issuances',
+    securityIdField: 'convertible_issuances_by_security_id',
+    batchName: 'ConvertibleIssuance',
+  },
+  convertibleRetraction: {
+    objectType: 'TX_CONVERTIBLE_RETRACTION',
+    dataField: 'retraction_data',
+    capTableField: 'convertible_retractions',
+    batchName: 'ConvertibleRetraction',
+  },
+  convertibleTransfer: {
+    objectType: 'TX_CONVERTIBLE_TRANSFER',
+    dataField: 'transfer_data',
+    capTableField: 'convertible_transfers',
+    batchName: 'ConvertibleTransfer',
+  },
+  document: {
+    objectType: 'DOCUMENT',
+    dataField: 'document_data',
+    capTableField: 'documents',
+    batchName: 'Document',
+  },
+  equityCompensationAcceptance: {
+    objectType: 'TX_EQUITY_COMPENSATION_ACCEPTANCE',
+    dataField: 'acceptance_data',
+    capTableField: 'equity_compensation_acceptances',
+    batchName: 'EquityCompensationAcceptance',
+  },
+  equityCompensationCancellation: {
+    objectType: 'TX_EQUITY_COMPENSATION_CANCELLATION',
+    dataField: 'cancellation_data',
+    capTableField: 'equity_compensation_cancellations',
+    batchName: 'EquityCompensationCancellation',
+  },
+  equityCompensationExercise: {
+    objectType: 'TX_EQUITY_COMPENSATION_EXERCISE',
+    dataField: 'exercise_data',
+    capTableField: 'equity_compensation_exercises',
+    batchName: 'EquityCompensationExercise',
+  },
+  equityCompensationIssuance: {
+    objectType: 'TX_EQUITY_COMPENSATION_ISSUANCE',
+    dataField: 'issuance_data',
+    capTableField: 'equity_compensation_issuances',
+    securityIdField: 'equity_compensation_issuances_by_security_id',
+    batchName: 'EquityCompensationIssuance',
+  },
+  equityCompensationRelease: {
+    objectType: 'TX_EQUITY_COMPENSATION_RELEASE',
+    dataField: 'release_data',
+    capTableField: 'equity_compensation_releases',
+    batchName: 'EquityCompensationRelease',
+  },
+  equityCompensationRepricing: {
+    objectType: 'TX_EQUITY_COMPENSATION_REPRICING',
+    dataField: 'repricing_data',
+    capTableField: 'equity_compensation_repricings',
+    batchName: 'EquityCompensationRepricing',
+  },
+  equityCompensationRetraction: {
+    objectType: 'TX_EQUITY_COMPENSATION_RETRACTION',
+    dataField: 'retraction_data',
+    capTableField: 'equity_compensation_retractions',
+    batchName: 'EquityCompensationRetraction',
+  },
+  equityCompensationTransfer: {
+    objectType: 'TX_EQUITY_COMPENSATION_TRANSFER',
+    dataField: 'transfer_data',
+    capTableField: 'equity_compensation_transfers',
+    batchName: 'EquityCompensationTransfer',
+  },
+  issuer: {
+    objectType: 'ISSUER',
+    dataField: 'issuer_data',
+    batchName: 'Issuer',
+    supportsCreate: false,
+    supportsDelete: false,
+  },
+  issuerAuthorizedSharesAdjustment: {
+    objectType: 'TX_ISSUER_AUTHORIZED_SHARES_ADJUSTMENT',
+    dataField: 'adjustment_data',
+    capTableField: 'issuer_authorized_shares_adjustments',
+    batchName: 'IssuerAuthorizedSharesAdjustment',
+  },
+  planSecurityAcceptance: {
+    objectType: 'TX_EQUITY_COMPENSATION_ACCEPTANCE',
+    dataField: 'acceptance_data',
+    batchName: 'EquityCompensationAcceptance',
+  },
+  planSecurityCancellation: {
+    objectType: 'TX_EQUITY_COMPENSATION_CANCELLATION',
+    dataField: 'cancellation_data',
+    batchName: 'EquityCompensationCancellation',
+  },
+  planSecurityExercise: {
+    objectType: 'TX_EQUITY_COMPENSATION_EXERCISE',
+    dataField: 'exercise_data',
+    batchName: 'EquityCompensationExercise',
+  },
+  planSecurityIssuance: {
+    objectType: 'TX_EQUITY_COMPENSATION_ISSUANCE',
+    dataField: 'issuance_data',
+    batchName: 'EquityCompensationIssuance',
+  },
+  planSecurityRelease: {
+    objectType: 'TX_EQUITY_COMPENSATION_RELEASE',
+    dataField: 'release_data',
+    batchName: 'EquityCompensationRelease',
+  },
+  planSecurityRetraction: {
+    objectType: 'TX_EQUITY_COMPENSATION_RETRACTION',
+    dataField: 'retraction_data',
+    batchName: 'EquityCompensationRetraction',
+  },
+  planSecurityTransfer: {
+    objectType: 'TX_EQUITY_COMPENSATION_TRANSFER',
+    dataField: 'transfer_data',
+    batchName: 'EquityCompensationTransfer',
+  },
+  stakeholder: {
+    objectType: 'STAKEHOLDER',
+    dataField: 'stakeholder_data',
+    capTableField: 'stakeholders',
+    batchName: 'Stakeholder',
+  },
+  stakeholderRelationshipChangeEvent: {
+    objectType: 'CE_STAKEHOLDER_RELATIONSHIP',
+    dataField: 'relationship_change_data',
+    dataFieldFallbacks: ['event_data'],
+    capTableField: 'stakeholder_relationship_change_events',
+    batchName: 'StakeholderRelationshipChangeEvent',
+  },
+  stakeholderStatusChangeEvent: {
+    objectType: 'CE_STAKEHOLDER_STATUS',
+    dataField: 'status_change_data',
+    dataFieldFallbacks: ['event_data'],
+    capTableField: 'stakeholder_status_change_events',
+    batchName: 'StakeholderStatusChangeEvent',
+  },
+  stockAcceptance: {
+    objectType: 'TX_STOCK_ACCEPTANCE',
+    dataField: 'acceptance_data',
+    capTableField: 'stock_acceptances',
+    batchName: 'StockAcceptance',
+  },
+  stockCancellation: {
+    objectType: 'TX_STOCK_CANCELLATION',
+    dataField: 'cancellation_data',
+    capTableField: 'stock_cancellations',
+    batchName: 'StockCancellation',
+  },
+  stockClass: {
+    objectType: 'STOCK_CLASS',
+    dataField: 'stock_class_data',
+    capTableField: 'stock_classes',
+    batchName: 'StockClass',
+  },
+  stockClassAuthorizedSharesAdjustment: {
+    objectType: 'TX_STOCK_CLASS_AUTHORIZED_SHARES_ADJUSTMENT',
+    dataField: 'adjustment_data',
+    capTableField: 'stock_class_authorized_shares_adjustments',
+    batchName: 'StockClassAuthorizedSharesAdjustment',
+  },
+  stockClassConversionRatioAdjustment: {
+    objectType: 'TX_STOCK_CLASS_CONVERSION_RATIO_ADJUSTMENT',
+    dataField: 'adjustment_data',
+    capTableField: 'stock_class_conversion_ratio_adjustments',
+    batchName: 'StockClassConversionRatioAdjustment',
+  },
+  stockClassSplit: {
+    objectType: 'TX_STOCK_CLASS_SPLIT',
+    dataField: 'split_data',
+    capTableField: 'stock_class_splits',
+    batchName: 'StockClassSplit',
+  },
+  stockConsolidation: {
+    objectType: 'TX_STOCK_CONSOLIDATION',
+    dataField: 'consolidation_data',
+    capTableField: 'stock_consolidations',
+    batchName: 'StockConsolidation',
+  },
+  stockConversion: {
+    objectType: 'TX_STOCK_CONVERSION',
+    dataField: 'conversion_data',
+    capTableField: 'stock_conversions',
+    batchName: 'StockConversion',
+  },
+  stockIssuance: {
+    objectType: 'TX_STOCK_ISSUANCE',
+    dataField: 'issuance_data',
+    capTableField: 'stock_issuances',
+    securityIdField: 'stock_issuances_by_security_id',
+    batchName: 'StockIssuance',
+  },
+  stockLegendTemplate: {
+    objectType: 'STOCK_LEGEND_TEMPLATE',
+    dataField: 'template_data',
+    capTableField: 'stock_legend_templates',
+    batchName: 'StockLegendTemplate',
+  },
+  stockPlan: {
+    objectType: 'STOCK_PLAN',
+    dataField: 'stock_plan_data',
+    capTableField: 'stock_plans',
+    batchName: 'StockPlan',
+  },
+  stockPlanPoolAdjustment: {
+    objectType: 'TX_STOCK_PLAN_POOL_ADJUSTMENT',
+    dataField: 'adjustment_data',
+    capTableField: 'stock_plan_pool_adjustments',
+    batchName: 'StockPlanPoolAdjustment',
+  },
+  stockPlanReturnToPool: {
+    objectType: 'TX_STOCK_PLAN_RETURN_TO_POOL',
+    dataField: 'return_data',
+    capTableField: 'stock_plan_return_to_pools',
+    batchName: 'StockPlanReturnToPool',
+  },
+  stockReissuance: {
+    objectType: 'TX_STOCK_REISSUANCE',
+    dataField: 'reissuance_data',
+    capTableField: 'stock_reissuances',
+    batchName: 'StockReissuance',
+  },
+  stockRepurchase: {
+    objectType: 'TX_STOCK_REPURCHASE',
+    dataField: 'repurchase_data',
+    capTableField: 'stock_repurchases',
+    batchName: 'StockRepurchase',
+  },
+  stockRetraction: {
+    objectType: 'TX_STOCK_RETRACTION',
+    dataField: 'retraction_data',
+    capTableField: 'stock_retractions',
+    batchName: 'StockRetraction',
+  },
+  stockTransfer: {
+    objectType: 'TX_STOCK_TRANSFER',
+    dataField: 'transfer_data',
+    capTableField: 'stock_transfers',
+    batchName: 'StockTransfer',
+  },
+  valuation: {
+    objectType: 'VALUATION',
+    dataField: 'valuation_data',
+    capTableField: 'valuations',
+    batchName: 'Valuation',
+  },
+  vestingAcceleration: {
+    objectType: 'TX_VESTING_ACCELERATION',
+    dataField: 'acceleration_data',
+    dataFieldFallbacks: ['vesting_acceleration_data'],
+    capTableField: 'vesting_accelerations',
+    batchName: 'VestingAcceleration',
+  },
+  vestingEvent: {
+    objectType: 'TX_VESTING_EVENT',
+    dataField: 'vesting_data',
+    dataFieldFallbacks: ['vesting_event_data'],
+    capTableField: 'vesting_events',
+    batchName: 'VestingEvent',
+  },
+  vestingStart: {
+    objectType: 'TX_VESTING_START',
+    dataField: 'vesting_data',
+    dataFieldFallbacks: ['vesting_start_data'],
+    capTableField: 'vesting_starts',
+    batchName: 'VestingStart',
+  },
+  vestingTerms: {
+    objectType: 'VESTING_TERMS',
+    dataField: 'vesting_terms_data',
+    capTableField: 'vesting_terms',
+    batchName: 'VestingTerms',
+  },
+  warrantAcceptance: {
+    objectType: 'TX_WARRANT_ACCEPTANCE',
+    dataField: 'acceptance_data',
+    capTableField: 'warrant_acceptances',
+    batchName: 'WarrantAcceptance',
+  },
+  warrantCancellation: {
+    objectType: 'TX_WARRANT_CANCELLATION',
+    dataField: 'cancellation_data',
+    capTableField: 'warrant_cancellations',
+    batchName: 'WarrantCancellation',
+  },
+  warrantExercise: {
+    objectType: 'TX_WARRANT_EXERCISE',
+    dataField: 'exercise_data',
+    capTableField: 'warrant_exercises',
+    batchName: 'WarrantExercise',
+  },
+  warrantIssuance: {
+    objectType: 'TX_WARRANT_ISSUANCE',
+    dataField: 'issuance_data',
+    capTableField: 'warrant_issuances',
+    securityIdField: 'warrant_issuances_by_security_id',
+    batchName: 'WarrantIssuance',
+  },
+  warrantRetraction: {
+    objectType: 'TX_WARRANT_RETRACTION',
+    dataField: 'retraction_data',
+    capTableField: 'warrant_retractions',
+    batchName: 'WarrantRetraction',
+  },
+  warrantTransfer: {
+    objectType: 'TX_WARRANT_TRANSFER',
+    dataField: 'transfer_data',
+    capTableField: 'warrant_transfers',
+    batchName: 'WarrantTransfer',
+  },
+} as const satisfies Record<OcfEntityType, OcfEntityRegistryEntry>;
+
+function entityRegistryEntries(): Array<[OcfEntityType, OcfEntityRegistryEntry]> {
+  return Object.entries(ENTITY_REGISTRY) as Array<[OcfEntityType, OcfEntityRegistryEntry]>;
+}
+
+function mapRegistryValues<TValue>(
+  selector: (entry: OcfEntityRegistryEntry, entityType: OcfEntityType) => TValue
+): Record<OcfEntityType, TValue> {
+  return Object.fromEntries(
+    entityRegistryEntries().map(([entityType, entry]) => [entityType, selector(entry, entityType)])
+  ) as Record<OcfEntityType, TValue>;
+}
+
+function partialMapFromRegistry<TValue>(
+  selector: (entry: OcfEntityRegistryEntry, entityType: OcfEntityType) => TValue | undefined
+): Partial<Record<OcfEntityType, TValue>> {
+  return Object.fromEntries(
+    entityRegistryEntries()
+      .map(([entityType, entry]) => [entityType, selector(entry, entityType)] as const)
+      .filter((entry): entry is readonly [OcfEntityType, TValue] => entry[1] !== undefined)
+  );
+}
+
+/** Mapping from entity type to canonical OCF object_type. */
+export const ENTITY_OBJECT_TYPE_MAP = mapRegistryValues((entry) => entry.objectType);
+
+/** Mapping from entity type to DAML create-argument data field. */
+export const ENTITY_DATA_FIELD_MAP = mapRegistryValues((entry) => entry.dataField);
+
+/** Alternate DAML field names used when the canonical field is missing. */
+export const ENTITY_DATA_FIELD_FALLBACK_MAP = partialMapFromRegistry((entry) => entry.dataFieldFallbacks);
+
+/** Mapping from CapTable contract field names to OCF entity types. */
+export const FIELD_TO_ENTITY_TYPE = Object.fromEntries(
+  entityRegistryEntries()
+    .filter((entry): entry is [OcfEntityType, OcfEntityRegistryEntry & { capTableField: string }] => {
+      const [, metadata] = entry;
+      return metadata.capTableField !== undefined;
+    })
+    .map(([entityType, metadata]) => [metadata.capTableField, entityType])
+);
+
+/** Mapping from CapTable `*_by_security_id` fields to issuance entity types. */
+export const SECURITY_ID_FIELD_TO_ENTITY_TYPE = Object.fromEntries(
+  entityRegistryEntries()
+    .filter((entry): entry is [OcfEntityType, OcfEntityRegistryEntry & { securityIdField: string }] => {
+      const [, metadata] = entry;
+      return metadata.securityIdField !== undefined;
+    })
+    .map(([entityType, metadata]) => [metadata.securityIdField, entityType])
+);
+
 /**
  * Mapping from entity type to DAML tag names.
  *
- * Note: PlanSecurity types use the same DAML tags as their EquityCompensation equivalents
- * since the underlying DAML contracts are the same.
+ * PlanSecurity entries derive EquityCompensation tags from ENTITY_REGISTRY because the underlying DAML unions are the
+ * same.
  */
-export const ENTITY_TAG_MAP: Record<
-  OcfEntityType,
-  { create: string | undefined; edit: string | undefined; delete: string | undefined }
-> = {
-  convertibleAcceptance: {
-    create: 'OcfCreateConvertibleAcceptance',
-    edit: 'OcfEditConvertibleAcceptance',
-    delete: 'OcfDeleteConvertibleAcceptance',
-  },
-  convertibleCancellation: {
-    create: 'OcfCreateConvertibleCancellation',
-    edit: 'OcfEditConvertibleCancellation',
-    delete: 'OcfDeleteConvertibleCancellation',
-  },
-  convertibleConversion: {
-    create: 'OcfCreateConvertibleConversion',
-    edit: 'OcfEditConvertibleConversion',
-    delete: 'OcfDeleteConvertibleConversion',
-  },
-  convertibleIssuance: {
-    create: 'OcfCreateConvertibleIssuance',
-    edit: 'OcfEditConvertibleIssuance',
-    delete: 'OcfDeleteConvertibleIssuance',
-  },
-  convertibleRetraction: {
-    create: 'OcfCreateConvertibleRetraction',
-    edit: 'OcfEditConvertibleRetraction',
-    delete: 'OcfDeleteConvertibleRetraction',
-  },
-  convertibleTransfer: {
-    create: 'OcfCreateConvertibleTransfer',
-    edit: 'OcfEditConvertibleTransfer',
-    delete: 'OcfDeleteConvertibleTransfer',
-  },
-  document: {
-    create: 'OcfCreateDocument',
-    edit: 'OcfEditDocument',
-    delete: 'OcfDeleteDocument',
-  },
-  equityCompensationAcceptance: {
-    create: 'OcfCreateEquityCompensationAcceptance',
-    edit: 'OcfEditEquityCompensationAcceptance',
-    delete: 'OcfDeleteEquityCompensationAcceptance',
-  },
-  equityCompensationCancellation: {
-    create: 'OcfCreateEquityCompensationCancellation',
-    edit: 'OcfEditEquityCompensationCancellation',
-    delete: 'OcfDeleteEquityCompensationCancellation',
-  },
-  equityCompensationExercise: {
-    create: 'OcfCreateEquityCompensationExercise',
-    edit: 'OcfEditEquityCompensationExercise',
-    delete: 'OcfDeleteEquityCompensationExercise',
-  },
-  equityCompensationIssuance: {
-    create: 'OcfCreateEquityCompensationIssuance',
-    edit: 'OcfEditEquityCompensationIssuance',
-    delete: 'OcfDeleteEquityCompensationIssuance',
-  },
-  equityCompensationRelease: {
-    create: 'OcfCreateEquityCompensationRelease',
-    edit: 'OcfEditEquityCompensationRelease',
-    delete: 'OcfDeleteEquityCompensationRelease',
-  },
-  equityCompensationRepricing: {
-    create: 'OcfCreateEquityCompensationRepricing',
-    edit: 'OcfEditEquityCompensationRepricing',
-    delete: 'OcfDeleteEquityCompensationRepricing',
-  },
-  equityCompensationRetraction: {
-    create: 'OcfCreateEquityCompensationRetraction',
-    edit: 'OcfEditEquityCompensationRetraction',
-    delete: 'OcfDeleteEquityCompensationRetraction',
-  },
-  equityCompensationTransfer: {
-    create: 'OcfCreateEquityCompensationTransfer',
-    edit: 'OcfEditEquityCompensationTransfer',
-    delete: 'OcfDeleteEquityCompensationTransfer',
-  },
-  // Issuer is edit-only (created with CapTable via IssuerAuthorization, cannot be deleted)
-  issuer: {
-    create: undefined, // Not supported - use IssuerAuthorization.CreateCapTable
-    edit: 'OcfEditIssuer',
-    delete: undefined, // Not supported - issuer cannot be deleted
-  },
-  issuerAuthorizedSharesAdjustment: {
-    create: 'OcfCreateIssuerAuthorizedSharesAdjustment',
-    edit: 'OcfEditIssuerAuthorizedSharesAdjustment',
-    delete: 'OcfDeleteIssuerAuthorizedSharesAdjustment',
-  },
-  // PlanSecurity aliases - use EquityCompensation DAML tags
-  planSecurityAcceptance: {
-    create: 'OcfCreateEquityCompensationAcceptance',
-    edit: 'OcfEditEquityCompensationAcceptance',
-    delete: 'OcfDeleteEquityCompensationAcceptance',
-  },
-  planSecurityCancellation: {
-    create: 'OcfCreateEquityCompensationCancellation',
-    edit: 'OcfEditEquityCompensationCancellation',
-    delete: 'OcfDeleteEquityCompensationCancellation',
-  },
-  planSecurityExercise: {
-    create: 'OcfCreateEquityCompensationExercise',
-    edit: 'OcfEditEquityCompensationExercise',
-    delete: 'OcfDeleteEquityCompensationExercise',
-  },
-  planSecurityIssuance: {
-    create: 'OcfCreateEquityCompensationIssuance',
-    edit: 'OcfEditEquityCompensationIssuance',
-    delete: 'OcfDeleteEquityCompensationIssuance',
-  },
-  planSecurityRelease: {
-    create: 'OcfCreateEquityCompensationRelease',
-    edit: 'OcfEditEquityCompensationRelease',
-    delete: 'OcfDeleteEquityCompensationRelease',
-  },
-  planSecurityRetraction: {
-    create: 'OcfCreateEquityCompensationRetraction',
-    edit: 'OcfEditEquityCompensationRetraction',
-    delete: 'OcfDeleteEquityCompensationRetraction',
-  },
-  planSecurityTransfer: {
-    create: 'OcfCreateEquityCompensationTransfer',
-    edit: 'OcfEditEquityCompensationTransfer',
-    delete: 'OcfDeleteEquityCompensationTransfer',
-  },
-  stakeholder: {
-    create: 'OcfCreateStakeholder',
-    edit: 'OcfEditStakeholder',
-    delete: 'OcfDeleteStakeholder',
-  },
-  stakeholderRelationshipChangeEvent: {
-    create: 'OcfCreateStakeholderRelationshipChangeEvent',
-    edit: 'OcfEditStakeholderRelationshipChangeEvent',
-    delete: 'OcfDeleteStakeholderRelationshipChangeEvent',
-  },
-  stakeholderStatusChangeEvent: {
-    create: 'OcfCreateStakeholderStatusChangeEvent',
-    edit: 'OcfEditStakeholderStatusChangeEvent',
-    delete: 'OcfDeleteStakeholderStatusChangeEvent',
-  },
-  stockAcceptance: {
-    create: 'OcfCreateStockAcceptance',
-    edit: 'OcfEditStockAcceptance',
-    delete: 'OcfDeleteStockAcceptance',
-  },
-  stockCancellation: {
-    create: 'OcfCreateStockCancellation',
-    edit: 'OcfEditStockCancellation',
-    delete: 'OcfDeleteStockCancellation',
-  },
-  stockClass: {
-    create: 'OcfCreateStockClass',
-    edit: 'OcfEditStockClass',
-    delete: 'OcfDeleteStockClass',
-  },
-  stockClassAuthorizedSharesAdjustment: {
-    create: 'OcfCreateStockClassAuthorizedSharesAdjustment',
-    edit: 'OcfEditStockClassAuthorizedSharesAdjustment',
-    delete: 'OcfDeleteStockClassAuthorizedSharesAdjustment',
-  },
-  stockClassConversionRatioAdjustment: {
-    create: 'OcfCreateStockClassConversionRatioAdjustment',
-    edit: 'OcfEditStockClassConversionRatioAdjustment',
-    delete: 'OcfDeleteStockClassConversionRatioAdjustment',
-  },
-  stockClassSplit: {
-    create: 'OcfCreateStockClassSplit',
-    edit: 'OcfEditStockClassSplit',
-    delete: 'OcfDeleteStockClassSplit',
-  },
-  stockConsolidation: {
-    create: 'OcfCreateStockConsolidation',
-    edit: 'OcfEditStockConsolidation',
-    delete: 'OcfDeleteStockConsolidation',
-  },
-  stockConversion: {
-    create: 'OcfCreateStockConversion',
-    edit: 'OcfEditStockConversion',
-    delete: 'OcfDeleteStockConversion',
-  },
-  stockIssuance: {
-    create: 'OcfCreateStockIssuance',
-    edit: 'OcfEditStockIssuance',
-    delete: 'OcfDeleteStockIssuance',
-  },
-  stockLegendTemplate: {
-    create: 'OcfCreateStockLegendTemplate',
-    edit: 'OcfEditStockLegendTemplate',
-    delete: 'OcfDeleteStockLegendTemplate',
-  },
-  stockPlan: {
-    create: 'OcfCreateStockPlan',
-    edit: 'OcfEditStockPlan',
-    delete: 'OcfDeleteStockPlan',
-  },
-  stockPlanPoolAdjustment: {
-    create: 'OcfCreateStockPlanPoolAdjustment',
-    edit: 'OcfEditStockPlanPoolAdjustment',
-    delete: 'OcfDeleteStockPlanPoolAdjustment',
-  },
-  stockPlanReturnToPool: {
-    create: 'OcfCreateStockPlanReturnToPool',
-    edit: 'OcfEditStockPlanReturnToPool',
-    delete: 'OcfDeleteStockPlanReturnToPool',
-  },
-  stockReissuance: {
-    create: 'OcfCreateStockReissuance',
-    edit: 'OcfEditStockReissuance',
-    delete: 'OcfDeleteStockReissuance',
-  },
-  stockRepurchase: {
-    create: 'OcfCreateStockRepurchase',
-    edit: 'OcfEditStockRepurchase',
-    delete: 'OcfDeleteStockRepurchase',
-  },
-  stockRetraction: {
-    create: 'OcfCreateStockRetraction',
-    edit: 'OcfEditStockRetraction',
-    delete: 'OcfDeleteStockRetraction',
-  },
-  stockTransfer: {
-    create: 'OcfCreateStockTransfer',
-    edit: 'OcfEditStockTransfer',
-    delete: 'OcfDeleteStockTransfer',
-  },
-  valuation: {
-    create: 'OcfCreateValuation',
-    edit: 'OcfEditValuation',
-    delete: 'OcfDeleteValuation',
-  },
-  vestingAcceleration: {
-    create: 'OcfCreateVestingAcceleration',
-    edit: 'OcfEditVestingAcceleration',
-    delete: 'OcfDeleteVestingAcceleration',
-  },
-  vestingEvent: {
-    create: 'OcfCreateVestingEvent',
-    edit: 'OcfEditVestingEvent',
-    delete: 'OcfDeleteVestingEvent',
-  },
-  vestingStart: {
-    create: 'OcfCreateVestingStart',
-    edit: 'OcfEditVestingStart',
-    delete: 'OcfDeleteVestingStart',
-  },
-  vestingTerms: {
-    create: 'OcfCreateVestingTerms',
-    edit: 'OcfEditVestingTerms',
-    delete: 'OcfDeleteVestingTerms',
-  },
-  warrantAcceptance: {
-    create: 'OcfCreateWarrantAcceptance',
-    edit: 'OcfEditWarrantAcceptance',
-    delete: 'OcfDeleteWarrantAcceptance',
-  },
-  warrantCancellation: {
-    create: 'OcfCreateWarrantCancellation',
-    edit: 'OcfEditWarrantCancellation',
-    delete: 'OcfDeleteWarrantCancellation',
-  },
-  warrantExercise: {
-    create: 'OcfCreateWarrantExercise',
-    edit: 'OcfEditWarrantExercise',
-    delete: 'OcfDeleteWarrantExercise',
-  },
-  warrantIssuance: {
-    create: 'OcfCreateWarrantIssuance',
-    edit: 'OcfEditWarrantIssuance',
-    delete: 'OcfDeleteWarrantIssuance',
-  },
-  warrantRetraction: {
-    create: 'OcfCreateWarrantRetraction',
-    edit: 'OcfEditWarrantRetraction',
-    delete: 'OcfDeleteWarrantRetraction',
-  },
-  warrantTransfer: {
-    create: 'OcfCreateWarrantTransfer',
-    edit: 'OcfEditWarrantTransfer',
-    delete: 'OcfDeleteWarrantTransfer',
-  },
-};
+export const ENTITY_TAG_MAP = mapRegistryValues((entry) => ({
+  create: entry.supportsCreate === false ? undefined : `OcfCreate${entry.batchName}`,
+  edit: `OcfEdit${entry.batchName}`,
+  delete: entry.supportsDelete === false ? undefined : `OcfDelete${entry.batchName}`,
+}));

--- a/src/functions/OpenCapTable/capTable/damlToOcf.ts
+++ b/src/functions/OpenCapTable/capTable/damlToOcf.ts
@@ -13,7 +13,12 @@ import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
 import { OcpErrorCodes, OcpParseError } from '../../../errors';
 import type { ReadScopeParams } from '../../../types/common';
 import { readSingleContract } from '../shared/singleContractRead';
-import type { OcfDataTypeFor, OcfEntityType } from './batchTypes';
+import {
+  ENTITY_DATA_FIELD_FALLBACK_MAP,
+  ENTITY_DATA_FIELD_MAP,
+  type OcfDataTypeFor,
+  type OcfEntityType,
+} from './batchTypes';
 
 // Import converters from entity folders
 import { damlConvertibleAcceptanceToNative } from '../convertibleAcceptance/convertibleAcceptanceDataToDaml';
@@ -65,88 +70,7 @@ import { damlWarrantIssuanceDataToNative } from '../warrantIssuance/getWarrantIs
 import { damlWarrantRetractionToNative } from '../warrantRetraction/damlToOcf';
 import { damlWarrantTransferToNative } from '../warrantTransfer/damlToOcf';
 
-// ===== Data field name mapping for contract extraction =====
-
-/**
- * Maps entity types to the field name containing the entity data in the DAML contract.
- * For example, 'stakeholder' contracts have data in 'stakeholder_data' field.
- *
- * Note: PlanSecurity types use the same data fields as EquityCompensation since they
- * share the same underlying DAML contracts.
- */
-export const ENTITY_DATA_FIELD_MAP: Record<OcfEntityType, string> = {
-  convertibleAcceptance: 'acceptance_data',
-  convertibleCancellation: 'cancellation_data',
-  convertibleConversion: 'conversion_data',
-  convertibleIssuance: 'issuance_data',
-  convertibleRetraction: 'retraction_data',
-  convertibleTransfer: 'transfer_data',
-  document: 'document_data',
-  equityCompensationAcceptance: 'acceptance_data',
-  equityCompensationCancellation: 'cancellation_data',
-  equityCompensationExercise: 'exercise_data',
-  equityCompensationIssuance: 'issuance_data',
-  equityCompensationRelease: 'release_data',
-  equityCompensationRepricing: 'repricing_data',
-  equityCompensationRetraction: 'retraction_data',
-  equityCompensationTransfer: 'transfer_data',
-  // Issuer is edit-only (stored as a single reference in CapTable, not a map)
-  issuer: 'issuer_data',
-  issuerAuthorizedSharesAdjustment: 'adjustment_data',
-  // PlanSecurity aliases - use EquityCompensation data field names
-  planSecurityAcceptance: 'acceptance_data',
-  planSecurityCancellation: 'cancellation_data',
-  planSecurityExercise: 'exercise_data',
-  planSecurityIssuance: 'issuance_data',
-  planSecurityRelease: 'release_data',
-  planSecurityRetraction: 'retraction_data',
-  planSecurityTransfer: 'transfer_data',
-  stakeholder: 'stakeholder_data',
-  stakeholderRelationshipChangeEvent: 'relationship_change_data',
-  stakeholderStatusChangeEvent: 'status_change_data',
-  stockAcceptance: 'acceptance_data',
-  stockCancellation: 'cancellation_data',
-  stockClass: 'stock_class_data',
-  stockClassAuthorizedSharesAdjustment: 'adjustment_data',
-  stockClassConversionRatioAdjustment: 'adjustment_data',
-  stockClassSplit: 'split_data',
-  stockConsolidation: 'consolidation_data',
-  stockConversion: 'conversion_data',
-  stockIssuance: 'issuance_data',
-  stockLegendTemplate: 'template_data',
-  stockPlan: 'stock_plan_data',
-  stockPlanPoolAdjustment: 'adjustment_data',
-  stockPlanReturnToPool: 'return_data',
-  stockReissuance: 'reissuance_data',
-  stockRepurchase: 'repurchase_data',
-  stockRetraction: 'retraction_data',
-  stockTransfer: 'transfer_data',
-  valuation: 'valuation_data',
-  // Deployed DAML templates use these wrapper fields:
-  // - VestingStart/VestingEvent: vesting_data
-  // - VestingAcceleration: acceleration_data
-  vestingAcceleration: 'acceleration_data',
-  vestingEvent: 'vesting_data',
-  vestingStart: 'vesting_data',
-  vestingTerms: 'vesting_terms_data',
-  warrantAcceptance: 'acceptance_data',
-  warrantCancellation: 'cancellation_data',
-  warrantExercise: 'exercise_data',
-  warrantIssuance: 'issuance_data',
-  warrantRetraction: 'retraction_data',
-  warrantTransfer: 'transfer_data',
-};
-
-/**
- * Alternate DAML field names used when the canonical field in ENTITY_DATA_FIELD_MAP is missing.
- */
-export const ENTITY_DATA_FIELD_FALLBACK_MAP: Partial<Record<OcfEntityType, readonly string[]>> = {
-  stakeholderRelationshipChangeEvent: ['event_data'],
-  stakeholderStatusChangeEvent: ['event_data'],
-  vestingAcceleration: ['vesting_acceleration_data'],
-  vestingEvent: ['vesting_event_data'],
-  vestingStart: ['vesting_start_data'],
-};
+export { ENTITY_DATA_FIELD_FALLBACK_MAP, ENTITY_DATA_FIELD_MAP };
 
 // Note: DAML input type definitions and converter implementations have been moved to their
 // respective entity folders (e.g., stockTransfer/damlToOcf.ts) following the Entity Folder
@@ -160,76 +84,7 @@ export const ENTITY_DATA_FIELD_FALLBACK_MAP: Partial<Record<OcfEntityType, reado
  *
  * PlanSecurity types are aliases that delegate to EquityCompensation converters.
  */
-export type SupportedOcfReadType =
-  // Core objects
-  | 'document'
-  | 'issuer'
-  | 'stakeholder'
-  | 'stockClass'
-  | 'stockLegendTemplate'
-  | 'stockPlan'
-  | 'vestingTerms'
-  // Issuance types
-  | 'convertibleIssuance'
-  | 'equityCompensationIssuance'
-  | 'stockIssuance'
-  | 'warrantIssuance'
-  // Acceptance types
-  | 'convertibleAcceptance'
-  | 'equityCompensationAcceptance'
-  | 'stockAcceptance'
-  | 'warrantAcceptance'
-  // Cancellation types
-  | 'convertibleCancellation'
-  | 'equityCompensationCancellation'
-  | 'stockCancellation'
-  | 'warrantCancellation'
-  // Transfer types
-  | 'convertibleTransfer'
-  | 'equityCompensationTransfer'
-  | 'stockTransfer'
-  | 'warrantTransfer'
-  // Retraction types
-  | 'convertibleRetraction'
-  | 'equityCompensationRetraction'
-  | 'stockRetraction'
-  | 'warrantRetraction'
-  // Conversion types
-  | 'convertibleConversion'
-  | 'stockConversion'
-  // Exercise types
-  | 'equityCompensationExercise'
-  | 'warrantExercise'
-  // Release and other equity compensation
-  | 'equityCompensationRelease'
-  | 'equityCompensationRepricing'
-  // Stock adjustments
-  | 'stockClassAuthorizedSharesAdjustment'
-  | 'stockClassConversionRatioAdjustment'
-  | 'stockClassSplit'
-  | 'stockConsolidation'
-  | 'stockPlanPoolAdjustment'
-  | 'stockPlanReturnToPool'
-  | 'stockReissuance'
-  | 'stockRepurchase'
-  // Issuer adjustment
-  | 'issuerAuthorizedSharesAdjustment'
-  // Stakeholder events
-  | 'stakeholderRelationshipChangeEvent'
-  | 'stakeholderStatusChangeEvent'
-  // Valuation and vesting
-  | 'valuation'
-  | 'vestingAcceleration'
-  | 'vestingEvent'
-  | 'vestingStart'
-  // PlanSecurity aliases (delegate to EquityCompensation)
-  | 'planSecurityAcceptance'
-  | 'planSecurityCancellation'
-  | 'planSecurityExercise'
-  | 'planSecurityIssuance'
-  | 'planSecurityRelease'
-  | 'planSecurityRetraction'
-  | 'planSecurityTransfer';
+export type SupportedOcfReadType = OcfEntityType;
 
 /**
  * Convert DAML entity data to native OCF format based on entity type.

--- a/src/functions/OpenCapTable/capTable/getCapTableState.ts
+++ b/src/functions/OpenCapTable/capTable/getCapTableState.ts
@@ -35,7 +35,8 @@ import {
 } from '../../../utils/contractReadDiagnostics';
 import { ledgerReadScope } from '../../../utils/readScope';
 import { parseDamlMap } from '../../../utils/typeConversions';
-import type { OcfEntityType } from './batchTypes';
+import { FIELD_TO_ENTITY_TYPE, SECURITY_ID_FIELD_TO_ENTITY_TYPE, type OcfEntityType } from './batchTypes';
+export { FIELD_TO_ENTITY_TYPE, SECURITY_ID_FIELD_TO_ENTITY_TYPE } from './batchTypes';
 
 /** CapTable template ID this SDK treats as current (package-name symbolic form; used for ledger queries). */
 const CURRENT_CAP_TABLE_TEMPLATE_ID = OCP_TEMPLATES.capTable;
@@ -124,99 +125,6 @@ function isJsActiveContractItem(item: JsGetActiveContractsResponseItem): item is
 
   return true;
 }
-
-/**
- * Mapping from CapTable contract field names (snake_case) to OcfEntityType (camelCase).
- *
- * Each field in the CapTable DAML contract is a Map from canonical object ID (Text) to ContractId.
- * This mapping allows extraction of entity inventories from the contract payload.
- *
- * Note: planSecurity* types (7 total) are intentionally omitted from this mapping.
- * They are aliases for equityCompensation* types and are stored under equity_compensation_*
- * fields in Canton. The SDK normalizes planSecurity → equityCompensation during upload.
- */
-export const FIELD_TO_ENTITY_TYPE: Record<string, OcfEntityType> = {
-  // Core Objects (7 types)
-  stakeholders: 'stakeholder',
-  stock_classes: 'stockClass',
-  stock_plans: 'stockPlan',
-  vesting_terms: 'vestingTerms',
-  stock_legend_templates: 'stockLegendTemplate',
-  documents: 'document',
-  valuations: 'valuation',
-
-  // Stock Class Adjustments (4 types)
-  stock_class_authorized_shares_adjustments: 'stockClassAuthorizedSharesAdjustment',
-  stock_class_conversion_ratio_adjustments: 'stockClassConversionRatioAdjustment',
-  stock_class_splits: 'stockClassSplit',
-  issuer_authorized_shares_adjustments: 'issuerAuthorizedSharesAdjustment',
-
-  // Stock Transactions (9 types)
-  stock_issuances: 'stockIssuance',
-  stock_cancellations: 'stockCancellation',
-  stock_transfers: 'stockTransfer',
-  stock_acceptances: 'stockAcceptance',
-  stock_conversions: 'stockConversion',
-  stock_repurchases: 'stockRepurchase',
-  stock_reissuances: 'stockReissuance',
-  stock_retractions: 'stockRetraction',
-  stock_consolidations: 'stockConsolidation',
-
-  // Equity Compensation (8 types)
-  equity_compensation_issuances: 'equityCompensationIssuance',
-  equity_compensation_cancellations: 'equityCompensationCancellation',
-  equity_compensation_transfers: 'equityCompensationTransfer',
-  equity_compensation_acceptances: 'equityCompensationAcceptance',
-  equity_compensation_exercises: 'equityCompensationExercise',
-  equity_compensation_releases: 'equityCompensationRelease',
-  equity_compensation_repricings: 'equityCompensationRepricing',
-  equity_compensation_retractions: 'equityCompensationRetraction',
-
-  // Convertibles (6 types)
-  convertible_issuances: 'convertibleIssuance',
-  convertible_cancellations: 'convertibleCancellation',
-  convertible_transfers: 'convertibleTransfer',
-  convertible_acceptances: 'convertibleAcceptance',
-  convertible_conversions: 'convertibleConversion',
-  convertible_retractions: 'convertibleRetraction',
-
-  // Warrants (6 types)
-  warrant_issuances: 'warrantIssuance',
-  warrant_cancellations: 'warrantCancellation',
-  warrant_transfers: 'warrantTransfer',
-  warrant_acceptances: 'warrantAcceptance',
-  warrant_exercises: 'warrantExercise',
-  warrant_retractions: 'warrantRetraction',
-
-  // Stock Plan Events (2 types)
-  stock_plan_pool_adjustments: 'stockPlanPoolAdjustment',
-  stock_plan_return_to_pools: 'stockPlanReturnToPool',
-
-  // Vesting Events (3 types)
-  vesting_accelerations: 'vestingAcceleration',
-  vesting_events: 'vestingEvent',
-  vesting_starts: 'vestingStart',
-
-  // Stakeholder Events (2 types)
-  stakeholder_relationship_change_events: 'stakeholderRelationshipChangeEvent',
-  stakeholder_status_change_events: 'stakeholderStatusChangeEvent',
-};
-
-/**
- * Mapping from CapTable `*_by_security_id` fields to OcfEntityType.
- *
- * These maps track security_id uniqueness for issuance types. The keys are
- * security_id values (not canonical object IDs), and the values are ContractIds.
- *
- * Used by the replication diff to detect duplicate security_id conflicts
- * before submitting to DAML (which would fail with "security_id already exists").
- */
-export const SECURITY_ID_FIELD_TO_ENTITY_TYPE: Record<string, OcfEntityType> = {
-  stock_issuances_by_security_id: 'stockIssuance',
-  convertible_issuances_by_security_id: 'convertibleIssuance',
-  equity_compensation_issuances_by_security_id: 'equityCompensationIssuance',
-  warrant_issuances_by_security_id: 'warrantIssuance',
-};
 
 /**
  * Current state of a CapTable on Canton, with all canonical object IDs grouped by entity type.

--- a/src/utils/cantonOcfExtractor.ts
+++ b/src/utils/cantonOcfExtractor.ts
@@ -13,7 +13,7 @@
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
 import { OcpErrorCodes } from '../errors/codes';
 import { OcpValidationError } from '../errors/OcpValidationError';
-import type { OcfEntityType } from '../functions/OpenCapTable/capTable/batchTypes';
+import { ENTITY_OBJECT_TYPE_MAP, type OcfEntityType } from '../functions/OpenCapTable/capTable/batchTypes';
 import type { SupportedOcfReadType } from '../functions/OpenCapTable/capTable/damlToOcf';
 import { getEntityAsOcf } from '../functions/OpenCapTable/capTable/damlToOcf';
 import type { CapTableState } from '../functions/OpenCapTable/capTable/getCapTableState';
@@ -38,9 +38,7 @@ import {
   contractReadFailureCode,
   createDiagnosedContractReadError,
 } from './contractReadDiagnostics';
-import { LEGACY_OBJECT_TYPE_MAP } from './planSecurityAliases';
 import { ledgerReadScope } from './readScope';
-import { TRANSACTION_SUBTYPE_MAP } from './replicationHelpers';
 
 // ===== Transaction Sorting =====
 // These utilities ensure Canton transactions are sorted consistently with DB data.
@@ -297,20 +295,6 @@ const TRANSACTION_ENTITY_TYPES: Set<OcfEntityType> = new Set([
   'vestingEvent',
   'vestingStart',
 ]);
-
-/**
- * Maps entity types to their OCF object_type values.
- * Used to ensure transactions fetched via the generic getEntityAsOcf path
- * have the correct object_type for sorting.
- *
- * Derived programmatically from TRANSACTION_SUBTYPE_MAP to avoid maintaining
- * duplicate inverse mappings that could drift out of sync.
- */
-const ENTITY_TYPE_TO_OBJECT_TYPE: Record<string, string> = Object.fromEntries(
-  Object.entries(TRANSACTION_SUBTYPE_MAP)
-    .filter(([objectType]) => !Object.prototype.hasOwnProperty.call(LEGACY_OBJECT_TYPE_MAP, objectType))
-    .map(([objectType, entityType]) => [entityType, objectType])
-);
 
 /**
  * Entity types supported by getEntityAsOcf dispatcher.
@@ -579,7 +563,7 @@ export async function extractCantonOcfManifest(
             // Ensure object_type is present for correct sorting
             // Generic converters may not include it, so we add it from our mapping
             const existingObjectType = typeof txData.object_type === 'string' ? txData.object_type : null;
-            const mappedObjectType = ENTITY_TYPE_TO_OBJECT_TYPE[entityType];
+            const mappedObjectType = ENTITY_OBJECT_TYPE_MAP[entityType];
 
             if (!existingObjectType && !mappedObjectType) {
               throw new OcpValidationError(

--- a/src/utils/ocfZodSchemas.ts
+++ b/src/utils/ocfZodSchemas.ts
@@ -407,7 +407,7 @@ export function parseOcfEntityInput<T extends OcfEntityType>(entityType: T, inpu
     });
   }
 
-  const expectedObjectType = ENTITY_OBJECT_TYPE_MAP[entityType] as OcfSchemaObjectType;
+  const expectedObjectType = resolveSchemaObjectType(ENTITY_OBJECT_TYPE_MAP[entityType]);
   const objectInput = input;
 
   const withObjectType =

--- a/src/utils/ocfZodSchemas.ts
+++ b/src/utils/ocfZodSchemas.ts
@@ -5,7 +5,11 @@ import fs from 'fs';
 import path from 'path';
 import { z, ZodError, type ZodType } from 'zod';
 import { OcpErrorCodes, OcpValidationError } from '../errors';
-import type { OcfDataTypeFor, OcfEntityType } from '../functions/OpenCapTable/capTable/batchTypes';
+import {
+  ENTITY_OBJECT_TYPE_MAP,
+  type OcfDataTypeFor,
+  type OcfEntityType,
+} from '../functions/OpenCapTable/capTable/batchTypes';
 import { normalizeOcfData } from './planSecurityAliases';
 
 /**
@@ -100,79 +104,6 @@ const LEGACY_OBJECT_TYPE_ALIASES: Partial<Record<string, OcfSchemaObjectType>> =
   TX_STAKEHOLDER_RELATIONSHIP_CHANGE_EVENT: 'CE_STAKEHOLDER_RELATIONSHIP',
   TX_STAKEHOLDER_STATUS_CHANGE_EVENT: 'CE_STAKEHOLDER_STATUS',
 };
-
-/**
- * Canonical object_type expected for each SDK entity type.
- */
-const ENTITY_TYPE_TO_OBJECT_TYPE: Record<OcfEntityType, OcfSchemaObjectType> = {
-  issuer: 'ISSUER',
-  stakeholder: 'STAKEHOLDER',
-  stockClass: 'STOCK_CLASS',
-  stockLegendTemplate: 'STOCK_LEGEND_TEMPLATE',
-  stockPlan: 'STOCK_PLAN',
-  vestingTerms: 'VESTING_TERMS',
-  valuation: 'VALUATION',
-  document: 'DOCUMENT',
-
-  stockIssuance: 'TX_STOCK_ISSUANCE',
-  stockCancellation: 'TX_STOCK_CANCELLATION',
-  stockTransfer: 'TX_STOCK_TRANSFER',
-  stockAcceptance: 'TX_STOCK_ACCEPTANCE',
-  stockConversion: 'TX_STOCK_CONVERSION',
-  stockRepurchase: 'TX_STOCK_REPURCHASE',
-  stockReissuance: 'TX_STOCK_REISSUANCE',
-  stockRetraction: 'TX_STOCK_RETRACTION',
-  stockConsolidation: 'TX_STOCK_CONSOLIDATION',
-
-  stockClassAuthorizedSharesAdjustment: 'TX_STOCK_CLASS_AUTHORIZED_SHARES_ADJUSTMENT',
-  stockClassConversionRatioAdjustment: 'TX_STOCK_CLASS_CONVERSION_RATIO_ADJUSTMENT',
-  stockClassSplit: 'TX_STOCK_CLASS_SPLIT',
-  issuerAuthorizedSharesAdjustment: 'TX_ISSUER_AUTHORIZED_SHARES_ADJUSTMENT',
-  stockPlanPoolAdjustment: 'TX_STOCK_PLAN_POOL_ADJUSTMENT',
-  stockPlanReturnToPool: 'TX_STOCK_PLAN_RETURN_TO_POOL',
-
-  convertibleIssuance: 'TX_CONVERTIBLE_ISSUANCE',
-  convertibleCancellation: 'TX_CONVERTIBLE_CANCELLATION',
-  convertibleTransfer: 'TX_CONVERTIBLE_TRANSFER',
-  convertibleAcceptance: 'TX_CONVERTIBLE_ACCEPTANCE',
-  convertibleConversion: 'TX_CONVERTIBLE_CONVERSION',
-  convertibleRetraction: 'TX_CONVERTIBLE_RETRACTION',
-
-  warrantIssuance: 'TX_WARRANT_ISSUANCE',
-  warrantCancellation: 'TX_WARRANT_CANCELLATION',
-  warrantTransfer: 'TX_WARRANT_TRANSFER',
-  warrantAcceptance: 'TX_WARRANT_ACCEPTANCE',
-  warrantExercise: 'TX_WARRANT_EXERCISE',
-  warrantRetraction: 'TX_WARRANT_RETRACTION',
-
-  equityCompensationIssuance: 'TX_EQUITY_COMPENSATION_ISSUANCE',
-  equityCompensationCancellation: 'TX_EQUITY_COMPENSATION_CANCELLATION',
-  equityCompensationTransfer: 'TX_EQUITY_COMPENSATION_TRANSFER',
-  equityCompensationAcceptance: 'TX_EQUITY_COMPENSATION_ACCEPTANCE',
-  equityCompensationExercise: 'TX_EQUITY_COMPENSATION_EXERCISE',
-  equityCompensationRelease: 'TX_EQUITY_COMPENSATION_RELEASE',
-  equityCompensationRetraction: 'TX_EQUITY_COMPENSATION_RETRACTION',
-  equityCompensationRepricing: 'TX_EQUITY_COMPENSATION_REPRICING',
-
-  // PlanSecurity aliases canonicalize to equity compensation
-  planSecurityIssuance: 'TX_EQUITY_COMPENSATION_ISSUANCE',
-  planSecurityCancellation: 'TX_EQUITY_COMPENSATION_CANCELLATION',
-  planSecurityTransfer: 'TX_EQUITY_COMPENSATION_TRANSFER',
-  planSecurityAcceptance: 'TX_EQUITY_COMPENSATION_ACCEPTANCE',
-  planSecurityExercise: 'TX_EQUITY_COMPENSATION_EXERCISE',
-  planSecurityRelease: 'TX_EQUITY_COMPENSATION_RELEASE',
-  planSecurityRetraction: 'TX_EQUITY_COMPENSATION_RETRACTION',
-
-  vestingAcceleration: 'TX_VESTING_ACCELERATION',
-  vestingEvent: 'TX_VESTING_EVENT',
-  vestingStart: 'TX_VESTING_START',
-
-  stakeholderRelationshipChangeEvent: 'CE_STAKEHOLDER_RELATIONSHIP',
-  stakeholderStatusChangeEvent: 'CE_STAKEHOLDER_STATUS',
-
-  // Included in object schemas though not currently modeled as SDK entity operations
-  // (kept here only to satisfy totality of Record<OcfEntityType,...>)
-} satisfies Record<OcfEntityType, OcfSchemaObjectType>;
 
 const OBJECTS_DIR_RELATIVE_PATH = 'objects';
 const SCHEMA_FILE_SUFFIX = '.schema.json';
@@ -476,7 +407,7 @@ export function parseOcfEntityInput<T extends OcfEntityType>(entityType: T, inpu
     });
   }
 
-  const expectedObjectType = ENTITY_TYPE_TO_OBJECT_TYPE[entityType];
+  const expectedObjectType = ENTITY_OBJECT_TYPE_MAP[entityType] as OcfSchemaObjectType;
   const objectInput = input;
 
   const withObjectType =

--- a/test/batch/CapTableBatch.test.ts
+++ b/test/batch/CapTableBatch.test.ts
@@ -443,6 +443,50 @@ describe('CapTableBatch', () => {
       await expect(batch.execute()).rejects.toThrow(/\[batch: 1 creates, 1 edits, 1 deletes/);
     });
 
+    it('should use provided commandId when executing', async () => {
+      const mockClient = {
+        submitAndWaitForTransactionTree: jest.fn().mockResolvedValue({
+          transactionTree: {
+            updateId: 'update-123',
+            eventsById: {
+              'event-1': {
+                ExercisedTreeEvent: {
+                  value: {
+                    choice: 'UpdateCapTable',
+                    exerciseResult: {
+                      updatedCapTableCid: 'cap-table-updated',
+                      createdCids: [],
+                      editedCids: [],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      };
+
+      const batch = new CapTableBatch(
+        {
+          capTableContractId: 'cap-table-123',
+          commandId: 'retry-safe-command-1',
+          actAs: ['party-1'],
+        },
+        mockClient as never
+      );
+
+      batch.delete('document', 'doc-123');
+
+      const result = await batch.execute();
+
+      expect(result.updateId).toBe('update-123');
+      expect(mockClient.submitAndWaitForTransactionTree).toHaveBeenCalledWith(
+        expect.objectContaining({
+          commandId: 'retry-safe-command-1',
+        })
+      );
+    });
+
     it('should throw RESULT_NOT_FOUND with batch context when UpdateCapTable result missing', async () => {
       // Mock a transaction tree that doesn't contain the UpdateCapTable exercised event
       const mockClient = {

--- a/test/client/OcpClient.test.ts
+++ b/test/client/OcpClient.test.ts
@@ -218,6 +218,7 @@ describe('OcpClient OpenCapTable entity facade', () => {
     expect(result).toEqual({
       contractId: 'stock-retraction-cid-1',
       data: {
+        object_type: 'TX_STOCK_RETRACTION',
         id: 'ret-1',
         date: '2025-01-01',
         security_id: 'stock-1',

--- a/test/client/OcpClient.test.ts
+++ b/test/client/OcpClient.test.ts
@@ -189,4 +189,44 @@ describe('OcpClient OpenCapTable entity facade', () => {
       readAs: ['issuer::party-1'],
     });
   });
+
+  it('exposes dispatcher-backed readers for transaction types missing dedicated facade wiring', async () => {
+    const ledger = {
+      getEventsByContractId: jest.fn().mockResolvedValue({
+        created: {
+          createdEvent: {
+            createArgument: {
+              retraction_data: {
+                id: 'ret-1',
+                date: '2025-01-01T00:00:00.000Z',
+                security_id: 'stock-1',
+                reason_text: 'Correction',
+                comments: [],
+              },
+            },
+          },
+        },
+      }),
+    };
+    const ocp = new OcpClient({ ledger: ledger as never });
+
+    const result = await ocp.OpenCapTable.stockRetraction.get({
+      contractId: 'stock-retraction-cid-1',
+      readAs: ['issuer::party-1'],
+    });
+
+    expect(result).toEqual({
+      contractId: 'stock-retraction-cid-1',
+      data: {
+        id: 'ret-1',
+        date: '2025-01-01',
+        security_id: 'stock-1',
+        reason_text: 'Correction',
+      },
+    });
+    expect(ledger.getEventsByContractId).toHaveBeenCalledWith({
+      contractId: 'stock-retraction-cid-1',
+      readAs: ['issuer::party-1'],
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- consolidate OCF entity metadata into a shared registry used by batch tags, read extraction, schema validation, cap table state extraction, and Canton manifest extraction
- add dispatcher-backed OpenCapTable facade readers for read-supported transaction types that were missing from OcpClient
- allow deterministic CapTableBatch commandId values for idempotent retries

## Validation
- npm run typecheck
- npm run lint
- npx prettier --check src/functions/OpenCapTable/capTable/batchTypes.ts src/functions/OpenCapTable/capTable/CapTableBatch.ts src/functions/OpenCapTable/capTable/damlToOcf.ts src/functions/OpenCapTable/capTable/getCapTableState.ts src/utils/cantonOcfExtractor.ts src/utils/ocfZodSchemas.ts src/OcpClient.ts test/batch/CapTableBatch.test.ts test/client/OcpClient.test.ts
- npm test -- --runInBand

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared metadata used across batch writes, ledger reads, schema validation, and cap table state—incorrect registry entries could mis-tag entities or break validation, but behavior is largely consolidation with added tests.
> 
> **Overview**
> Introduces **`ENTITY_REGISTRY`** in `batchTypes.ts` as the single source of truth for OCF entity metadata (`object_type`, DAML data fields, CapTable map fields, batch DAML tags). Derived maps (`ENTITY_TAG_MAP`, `ENTITY_OBJECT_TYPE_MAP`, `ENTITY_DATA_FIELD_MAP`, `FIELD_TO_ENTITY_TYPE`, `SECURITY_ID_FIELD_TO_ENTITY_TYPE`) are built from the registry instead of maintaining parallel hand-written tables in `damlToOcf.ts`, `getCapTableState.ts`, `ocfZodSchemas.ts`, and `cantonOcfExtractor.ts`.
> 
> **`OcpClient`** wires previously missing **read** APIs for retractions, equity compensation release/repricing, and stock plan return-to-pool via a shared **`getEntityAsOcf`** helper that injects `object_type` from the registry when converters omit it.
> 
> **`CapTableBatch`** / **`capTable.update`** accept an optional **`commandId`** so callers can retry `UpdateCapTable` submissions idempotently; otherwise behavior is unchanged (random command id).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 337936dcc6b30bc877ec0f61ed80f26a3859b6e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->