### PR TITLE
[codex] Add OCP write observability hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,33 @@ High-level TypeScript SDK for Open Cap Table Protocol contracts on Canton Networ
 
 All documentation, examples, architecture, and contributor information live on the
 **[GitHub wiki](https://github.com/Fairmint/ocp-canton-sdk/wiki)**.
+
+## Observability
+
+Write operations accept optional command context and observability hooks:
+
+```typescript
+const ocp = new OcpClient({
+  ledger: canton.ledger,
+  logger,
+  metrics,
+  defaultContext: { workflowId: 'issuer-onboarding' },
+});
+
+await ocp.OpenCapTable.capTable
+  .update({
+    capTableContractId,
+    actAs: [issuerParty],
+    context: {
+      commandId: 'create-stakeholder-123',
+      submissionId: 'submission-123',
+      traceContext: { traceId, spanId },
+    },
+  })
+  .create('stakeholder', stakeholder)
+  .execute();
+```
+
+`workflowId`, `commandId`, and `submissionId` are forwarded to Canton command submission.
+`traceContext` is included in SDK log context; the current `@fairmint/canton-node-sdk`
+submit-and-wait schema does not expose a submit-level trace context field yet.

--- a/README.md
+++ b/README.md
@@ -4,33 +4,3 @@ High-level TypeScript SDK for Open Cap Table Protocol contracts on Canton Networ
 
 All documentation, examples, architecture, and contributor information live on the
 **[GitHub wiki](https://github.com/Fairmint/ocp-canton-sdk/wiki)**.
-
-## Observability
-
-Write operations accept optional command context and observability hooks:
-
-```typescript
-const ocp = new OcpClient({
-  ledger: canton.ledger,
-  logger,
-  metrics,
-  defaultContext: { workflowId: 'issuer-onboarding' },
-});
-
-await ocp.OpenCapTable.capTable
-  .update({
-    capTableContractId,
-    actAs: [issuerParty],
-    context: {
-      commandId: 'create-stakeholder-123',
-      submissionId: 'submission-123',
-      traceContext: { traceId, spanId },
-    },
-  })
-  .create('stakeholder', stakeholder)
-  .execute();
-```
-
-`workflowId`, `commandId`, and `submissionId` are forwarded to Canton command submissions.
-`traceContext` is included in SDK log context; the current `@fairmint/canton-node-sdk`
-submit-and-wait schema does not expose a submit-level trace context field yet.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ await ocp.OpenCapTable.capTable
   .execute();
 ```
 
-`workflowId`, `commandId`, and `submissionId` are forwarded to Canton command submission.
+`workflowId`, `commandId`, and `submissionId` are forwarded to Canton command submissions.
 `traceContext` is included in SDK log context; the current `@fairmint/canton-node-sdk`
 submit-and-wait schema does not expose a submit-level trace context field yet.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "15.3.5",
     "@eslint/eslintrc": "3.3.5",
-    "@fairmint/canton-node-sdk": "0.0.206",
+    "@fairmint/canton-node-sdk": "0.0.207",
     "@fairmint/open-captable-protocol-daml-js": "0.2.161",
     "@types/jest": "30.0.0",
     "@types/jsonwebtoken": "9.0.10",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "typescript": "6.0.3"
   },
   "peerDependencies": {
-    "@fairmint/canton-node-sdk": ">=0.0.195 <0.1.0",
+    "@fairmint/canton-node-sdk": ">=0.0.207 <0.1.0",
     "@fairmint/open-captable-protocol-daml-js": ">=0.2.160 <0.3.0"
   },
   "publishConfig": {

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -985,7 +985,10 @@ interface CapTableUpdateParams extends CommandObservabilityOptions {
   capTableContractId: string;
   /** Optional contract details for the CapTable (used to get correct templateId from ledger) */
   capTableContractDetails?: { templateId: string };
-  /** Optional deterministic command ID for idempotent retry handling. */
+  /**
+   * Optional deterministic command ID for idempotent retry handling.
+   * If `context.commandId` is also set, `context.commandId` is submitted.
+   */
   commandId?: string;
   /** Party IDs to act as (signatories) */
   actAs: string[];

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -131,6 +131,7 @@ import {
   type CapTableState,
   type IssuerCapTableClassification,
 } from './functions/OpenCapTable/capTable';
+import { mergeCommandContext, type CommandObservabilityOptions, type OcpObservabilityOptions } from './observability';
 import type { CommandWithDisclosedContracts } from './types';
 import type { ContractResult, GetByContractIdParams } from './types/common';
 import type {
@@ -420,6 +421,9 @@ export class OcpClient {
   /** Logical Canton environment when this client was created through environment helpers. */
   public readonly environment?: OcpEnvironment;
 
+  /** Optional logger, metrics, and default command context for OCP write operations. */
+  public readonly observability: OcpObservabilityOptions;
+
   private productionSafetyChecksEnabled: boolean;
 
   /**
@@ -448,8 +452,22 @@ export class OcpClient {
         : { contractId: dependencies.factory.contractId, templateId: dependencies.factory.templateId };
     this.environment = dependencies.environment;
     this.productionSafetyChecksEnabled = dependencies.productionSafetyChecks ?? false;
+    const observability: OcpObservabilityOptions = {};
+    if (dependencies.logger !== undefined) observability.logger = dependencies.logger;
+    if (dependencies.metrics !== undefined) observability.metrics = dependencies.metrics;
+    if (dependencies.defaultContext !== undefined) observability.defaultContext = dependencies.defaultContext;
+    this.observability = observability;
 
     this.OpenCapTable = this.createOpenCapTableMethods();
+  }
+
+  private withObservability<T extends CommandObservabilityOptions>(params: T): T {
+    const defaultContext = mergeCommandContext(this.observability.defaultContext, params.defaultContext);
+    return {
+      ...this.observability,
+      ...params,
+      ...(defaultContext ? { defaultContext } : {}),
+    };
   }
 
   /**
@@ -846,25 +864,29 @@ export class OcpClient {
             );
           }
 
-          return authorizeIssuer(client, {
-            ...params,
-            ...(hasPerCallOverride
-              ? {}
-              : {
-                  factoryContractId: clientFactory?.contractId,
-                  factoryTemplateId: clientFactory?.templateId,
-                }),
-          });
+          return authorizeIssuer(
+            client,
+            this.withObservability({
+              ...params,
+              ...(hasPerCallOverride
+                ? {}
+                : {
+                    factoryContractId: clientFactory?.contractId,
+                    factoryTemplateId: clientFactory?.templateId,
+                  }),
+            })
+          );
         },
-        withdraw: async (params: WithdrawAuthorizationParams) => withdrawAuthorization(client, params),
+        withdraw: async (params: WithdrawAuthorizationParams) =>
+          withdrawAuthorization(client, this.withObservability(params)),
       },
 
       // ===== Batch Updates & Lifecycle =====
       capTable: {
         classify: async (issuerPartyId: string) => classifyIssuerCapTables(client, issuerPartyId),
         getState: async (issuerPartyId: string) => getCapTableState(client, issuerPartyId),
-        update: (params: CapTableUpdateParams) => new CapTableBatch(params, client),
-        archive: async (params: ArchiveCapTableParams) => archiveCapTable(client, params),
+        update: (params: CapTableUpdateParams) => new CapTableBatch(this.withObservability(params), client),
+        archive: async (params: ArchiveCapTableParams) => archiveCapTable(client, this.withObservability(params)),
       },
     };
   }
@@ -886,7 +908,7 @@ export interface OcpFactoryCoordinates {
  * Usually obtained from `new Canton({ network })` (or equivalent): pass `{ ledger: canton.ledger, validator: canton.validator }`.
  * **`validator`** is optional for cap-table-only usage of this SDK.
  */
-export interface OcpClientDependencies {
+export interface OcpClientDependencies extends OcpObservabilityOptions {
   readonly ledger: LedgerJsonApiClient;
   readonly validator?: ValidatorApiClient;
   /**
@@ -958,7 +980,7 @@ function validateInjectedEnvironment(environment: OcpEnvironment | undefined, le
 }
 
 /** Parameters for creating a batch cap table update */
-interface CapTableUpdateParams {
+interface CapTableUpdateParams extends CommandObservabilityOptions {
   /** The contract ID of the CapTable to update */
   capTableContractId: string;
   /** Optional contract details for the CapTable (used to get correct templateId from ledger) */

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -462,12 +462,15 @@ export class OcpClient {
   }
 
   private withObservability<T extends CommandObservabilityOptions>(params: T): T {
-    const defaultContext = mergeCommandContext(this.observability.defaultContext, params.defaultContext);
+    const { logger, metrics, defaultContext: paramsDefaultContext, ...commandParams } = params;
+    const defaultContext = mergeCommandContext(this.observability.defaultContext, paramsDefaultContext);
     return {
       ...this.observability,
-      ...params,
+      ...commandParams,
+      ...(logger !== undefined ? { logger } : {}),
+      ...(metrics !== undefined ? { metrics } : {}),
       ...(defaultContext ? { defaultContext } : {}),
-    };
+    } as T;
   }
 
   /**

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -987,7 +987,7 @@ interface CapTableUpdateParams extends CommandObservabilityOptions {
   capTableContractDetails?: { templateId: string };
   /**
    * Optional deterministic command ID for idempotent retry handling.
-   * If `context.commandId` is also set, `context.commandId` is submitted.
+   * Takes precedence over `defaultContext.commandId` and `context.commandId`.
    */
   commandId?: string;
   /** Party IDs to act as (signatories) */

--- a/src/functions/OpenCapTable/capTable/CapTableBatch.ts
+++ b/src/functions/OpenCapTable/capTable/CapTableBatch.ts
@@ -35,7 +35,7 @@ export interface CapTableBatchParams extends CommandObservabilityOptions {
   capTableContractDetails?: { templateId: string };
   /**
    * Optional deterministic command ID for callers that need idempotent retry semantics.
-   * If `context.commandId` is also set, `context.commandId` is submitted.
+   * Takes precedence over `defaultContext.commandId` and `context.commandId`.
    */
   commandId?: string;
   /** Party IDs to act as (signatories) */
@@ -253,13 +253,10 @@ export class CapTableBatch {
     let response: Awaited<ReturnType<LedgerJsonApiClient['submitAndWaitForTransactionTree']>>;
     try {
       const templateId = 'ExerciseCommand' in command ? command.ExerciseCommand.templateId : undefined;
-      const context = mergeCommandContext(
-        {
-          commandId: this.params.commandId ?? createUpdateCapTableCommandId(),
-        },
-        this.params.defaultContext,
-        this.params.context
-      );
+      const mergedContext = mergeCommandContext(this.params.defaultContext, this.params.context);
+      const context = mergeCommandContext(mergedContext, {
+        commandId: this.params.commandId ?? mergedContext?.commandId ?? createUpdateCapTableCommandId(),
+      });
       response = await submitObservedTransactionTree(
         this.client,
         {

--- a/src/functions/OpenCapTable/capTable/CapTableBatch.ts
+++ b/src/functions/OpenCapTable/capTable/CapTableBatch.ts
@@ -33,7 +33,10 @@ export interface CapTableBatchParams extends CommandObservabilityOptions {
   capTableContractId: string;
   /** Optional contract details for the CapTable (used to get correct templateId from ledger) */
   capTableContractDetails?: { templateId: string };
-  /** Optional deterministic command ID for callers that need idempotent retry semantics. */
+  /**
+   * Optional deterministic command ID for callers that need idempotent retry semantics.
+   * If `context.commandId` is also set, `context.commandId` is submitted.
+   */
   commandId?: string;
   /** Party IDs to act as (signatories) */
   actAs: string[];

--- a/src/functions/OpenCapTable/capTable/CapTableBatch.ts
+++ b/src/functions/OpenCapTable/capTable/CapTableBatch.ts
@@ -9,6 +9,11 @@ import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk/build/src/cl
 import type { Command } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/schemas/api/commands';
 import { OCP_TEMPLATES } from '@fairmint/open-captable-protocol-daml-js';
 import { OcpContractError, OcpErrorCodes, OcpValidationError } from '../../../errors';
+import {
+  mergeCommandContext,
+  submitObservedTransactionTree,
+  type CommandObservabilityOptions,
+} from '../../../observability';
 import type { CommandWithDisclosedContracts } from '../../../types';
 import {
   ENTITY_TAG_MAP,
@@ -23,7 +28,7 @@ import {
 import { convertToDaml } from './ocfToDaml';
 
 /** Parameters for initializing a batch update. */
-export interface CapTableBatchParams {
+export interface CapTableBatchParams extends CommandObservabilityOptions {
   /** The contract ID of the CapTable to update */
   capTableContractId: string;
   /** Optional contract details for the CapTable (used to get correct templateId from ledger) */
@@ -244,13 +249,29 @@ export class CapTableBatch {
 
     let response: Awaited<ReturnType<LedgerJsonApiClient['submitAndWaitForTransactionTree']>>;
     try {
-      response = await this.client.submitAndWaitForTransactionTree({
-        commands: [command],
-        commandId: this.params.commandId ?? createUpdateCapTableCommandId(),
-        actAs: this.params.actAs,
-        readAs: this.params.readAs,
-        disclosedContracts,
-      });
+      const templateId = 'ExerciseCommand' in command ? command.ExerciseCommand.templateId : undefined;
+      const context = mergeCommandContext(
+        {
+          commandId: this.params.commandId ?? createUpdateCapTableCommandId(),
+        },
+        this.params.defaultContext,
+        this.params.context
+      );
+      response = await submitObservedTransactionTree(
+        this.client,
+        {
+          commands: [command],
+          actAs: this.params.actAs,
+          readAs: this.params.readAs,
+          disclosedContracts,
+        },
+        { ...this.params, context },
+        {
+          operation: 'capTable.update',
+          templateId,
+          choice: 'UpdateCapTable',
+        }
+      );
     } catch (error) {
       // Wrap the error with batch context for better debugging
       const originalMessage = error instanceof Error ? error.message : String(error);

--- a/src/functions/OpenCapTable/capTable/archiveCapTable.ts
+++ b/src/functions/OpenCapTable/capTable/archiveCapTable.ts
@@ -10,11 +10,12 @@
 
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api';
 import { OcpErrorCodes, OcpValidationError } from '../../../errors';
+import { submitObservedTransactionTree, type CommandObservabilityOptions } from '../../../observability';
 import type { CommandWithDisclosedContracts } from '../../../types';
 import { buildCapTableCommand } from './buildCapTableCommand';
 
 /** Parameters for archiving a CapTable contract. */
-export interface ArchiveCapTableParams {
+export interface ArchiveCapTableParams extends CommandObservabilityOptions {
   /** The contract ID of the CapTable to archive */
   capTableContractId: string;
   /** Optional contract details for the CapTable (used to get correct templateId from ledger) */
@@ -89,12 +90,18 @@ export async function archiveCapTable(
 
   const { command, disclosedContracts } = buildArchiveCapTableCommand(params);
 
-  const result = await client.submitAndWaitForTransactionTree({
-    actAs: params.actAs,
-    readAs: params.readAs,
-    commands: [command],
-    disclosedContracts,
-  });
+  const templateId = 'ExerciseCommand' in command ? command.ExerciseCommand.templateId : undefined;
+  const result = await submitObservedTransactionTree(
+    client,
+    {
+      actAs: params.actAs,
+      readAs: params.readAs,
+      commands: [command],
+      disclosedContracts,
+    },
+    params,
+    { operation: 'archiveCapTable', templateId, choice: 'ArchiveCapTable' }
+  );
 
   return { updateId: result.transactionTree.updateId };
 }

--- a/src/functions/OpenCapTable/factory/createFactory.ts
+++ b/src/functions/OpenCapTable/factory/createFactory.ts
@@ -2,8 +2,9 @@ import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
 import { findCreatedEventByTemplateId } from '@fairmint/canton-node-sdk/build/src/utils/contracts/findCreatedEvent';
 import { OCP_TEMPLATES, type Fairmint } from '@fairmint/open-captable-protocol-daml-js';
 import { OcpContractError, OcpErrorCodes } from '../../../errors';
+import { submitObservedTransactionTree, type CommandObservabilityOptions } from '../../../observability';
 
-export interface CreateFactoryParams {
+export interface CreateFactoryParams extends CommandObservabilityOptions {
   /** Party ID that will own the factory (submits the create as this party). */
   systemOperator: string;
   /**
@@ -37,17 +38,22 @@ export async function createFactory(
     system_operator: params.systemOperator,
   };
 
-  const response = await client.submitAndWaitForTransactionTree({
-    commands: [
-      {
-        CreateCommand: {
-          templateId,
-          createArguments,
+  const response = await submitObservedTransactionTree(
+    client,
+    {
+      commands: [
+        {
+          CreateCommand: {
+            templateId,
+            createArguments,
+          },
         },
-      },
-    ],
-    actAs: [params.systemOperator],
-  });
+      ],
+      actAs: [params.systemOperator],
+    },
+    params,
+    { operation: 'createFactory', templateId, choice: 'Create' }
+  );
 
   const created = findCreatedEventByTemplateId(response, templateId);
   if (!created) {

--- a/src/functions/OpenCapTable/issuerAuthorization/authorizeIssuer.ts
+++ b/src/functions/OpenCapTable/issuerAuthorization/authorizeIssuer.ts
@@ -5,8 +5,9 @@ import { findCreatedEventByTemplateId } from '@fairmint/canton-node-sdk/build/sr
 import { OCP_TEMPLATES, type Fairmint } from '@fairmint/open-captable-protocol-daml-js';
 import factoryContractIdData from '@fairmint/open-captable-protocol-daml-js/ocp-factory-contract-id.json';
 import { OcpContractError, OcpErrorCodes, OcpValidationError } from '../../../errors';
+import { submitObservedTransactionTree, type CommandObservabilityOptions } from '../../../observability';
 
-export interface AuthorizeIssuerParams {
+export interface AuthorizeIssuerParams extends CommandObservabilityOptions {
   issuer: string; // Party ID of the issuer to authorize
   /** Override: factory contract ID (e.g. for staging). Requires factoryTemplateId. */
   factoryContractId?: string;
@@ -69,18 +70,23 @@ export async function authorizeIssuer(
   };
 
   // Submit the choice to the factory contract
-  const response = await client.submitAndWaitForTransactionTree({
-    commands: [
-      {
-        ExerciseCommand: {
-          templateId,
-          contractId,
-          choice: 'AuthorizeIssuer',
-          choiceArgument: choiceArguments,
+  const response = await submitObservedTransactionTree(
+    client,
+    {
+      commands: [
+        {
+          ExerciseCommand: {
+            templateId,
+            contractId,
+            choice: 'AuthorizeIssuer',
+            choiceArgument: choiceArguments,
+          },
         },
-      },
-    ],
-  });
+      ],
+    },
+    params,
+    { operation: 'authorizeIssuer', templateId, choice: 'AuthorizeIssuer' }
+  );
 
   const issuerAuthorizationTemplateId = OCP_TEMPLATES.issuerAuthorization;
   const created = findCreatedEventByTemplateId(response, issuerAuthorizationTemplateId);

--- a/src/functions/OpenCapTable/issuerAuthorization/withdrawAuthorization.ts
+++ b/src/functions/OpenCapTable/issuerAuthorization/withdrawAuthorization.ts
@@ -1,8 +1,9 @@
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
 import type { SubmitAndWaitForTransactionTreeResponse } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/operations';
 import { OCP_TEMPLATES } from '@fairmint/open-captable-protocol-daml-js';
+import { submitObservedTransactionTree, type CommandObservabilityOptions } from '../../../observability';
 
-export interface WithdrawAuthorizationParams {
+export interface WithdrawAuthorizationParams extends CommandObservabilityOptions {
   issuerAuthorizationContractId: string;
   systemOperatorParty: string;
 }
@@ -17,19 +18,28 @@ export async function withdrawAuthorization(
   params: WithdrawAuthorizationParams
 ): Promise<WithdrawAuthorizationResult> {
   const issuerAuthorizationTemplateId = OCP_TEMPLATES.issuerAuthorization;
-  const response = await client.submitAndWaitForTransactionTree({
-    actAs: [params.systemOperatorParty],
-    commands: [
-      {
-        ExerciseCommand: {
-          templateId: issuerAuthorizationTemplateId,
-          contractId: params.issuerAuthorizationContractId,
-          choice: 'WithdrawAuthorization',
-          choiceArgument: {},
+  const response = await submitObservedTransactionTree(
+    client,
+    {
+      actAs: [params.systemOperatorParty],
+      commands: [
+        {
+          ExerciseCommand: {
+            templateId: issuerAuthorizationTemplateId,
+            contractId: params.issuerAuthorizationContractId,
+            choice: 'WithdrawAuthorization',
+            choiceArgument: {},
+          },
         },
-      },
-    ],
-  });
+      ],
+    },
+    params,
+    {
+      operation: 'withdrawAuthorization',
+      templateId: issuerAuthorizationTemplateId,
+      choice: 'WithdrawAuthorization',
+    }
+  );
 
   return {
     updateId: response.transactionTree.updateId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './environment';
 export * from './errors';
 export * from './functions';
+export * from './observability';
 export * from './OcpClient';
 export * from './types';
 export * from './utils';

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -111,7 +111,7 @@ export async function submitObservedTransactionTree(
     workflowId: submitParams.workflowId,
     commandId: submitParams.commandId,
     submissionId: submitParams.submissionId,
-    traceContext: context?.traceContext,
+    traceContext: submitParams.traceContext,
   };
 
   runBestEffort(() => options?.logger?.debug('Submitting Canton command', logContext));

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,12 +1,9 @@
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
+import type { TraceContext } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/schemas/common';
 
 type SubmitTransactionTreeParams = Parameters<LedgerJsonApiClient['submitAndWaitForTransactionTree']>[0];
 type SubmitTransactionTreeResponse = Awaited<ReturnType<LedgerJsonApiClient['submitAndWaitForTransactionTree']>>;
-
-export interface CommandTraceContext {
-  traceId: string;
-  spanId: string;
-}
+type TraceableSubmitTransactionTreeParams = SubmitTransactionTreeParams & { traceContext?: TraceContext };
 
 export interface CommandContext {
   /** Business process ID persisted by Canton on submitted commands. */
@@ -15,14 +12,8 @@ export interface CommandContext {
   commandId?: string;
   /** Unique submission ID for retry tracking through completions. */
   submissionId?: string;
-  /**
-   * Distributed tracing metadata for SDK logs.
-   *
-   * The current canton-node-sdk submit-and-wait schema does not expose a
-   * submit-level traceContext field, so this is intentionally not forwarded to
-   * the ledger request yet.
-   */
-  traceContext?: CommandTraceContext;
+  /** Distributed tracing metadata forwarded to Canton command submissions and SDK logs. */
+  traceContext?: TraceContext;
 }
 
 export interface SdkLogger {
@@ -73,7 +64,7 @@ export function mergeCommandContext(
 function applyMergedCommandContext<T extends SubmitTransactionTreeParams>(
   params: T,
   context: CommandContext | undefined
-): T {
+): T & TraceableSubmitTransactionTreeParams {
   if (!context) return params;
 
   return {
@@ -81,6 +72,7 @@ function applyMergedCommandContext<T extends SubmitTransactionTreeParams>(
     ...(context.workflowId !== undefined ? { workflowId: context.workflowId } : {}),
     ...(context.commandId !== undefined ? { commandId: context.commandId } : {}),
     ...(context.submissionId !== undefined ? { submissionId: context.submissionId } : {}),
+    ...(context.traceContext !== undefined ? { traceContext: context.traceContext } : {}),
   };
 }
 
@@ -97,7 +89,7 @@ function runBestEffort(callback: (() => unknown) | undefined): void {
 export function applyCommandContext<T extends SubmitTransactionTreeParams>(
   params: T,
   options?: CommandObservabilityOptions
-): T {
+): T & TraceableSubmitTransactionTreeParams {
   const context = mergeCommandContext(options?.defaultContext, options?.context);
   return applyMergedCommandContext(params, context);
 }

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,0 +1,134 @@
+import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api';
+
+type SubmitTransactionTreeParams = Parameters<LedgerJsonApiClient['submitAndWaitForTransactionTree']>[0];
+type SubmitTransactionTreeResponse = Awaited<ReturnType<LedgerJsonApiClient['submitAndWaitForTransactionTree']>>;
+
+export interface CommandTraceContext {
+  traceId: string;
+  spanId: string;
+}
+
+export interface CommandContext {
+  /** Business process ID persisted by Canton on submitted commands. */
+  workflowId?: string;
+  /** Unique command ID for deduplication and operator diagnostics. */
+  commandId?: string;
+  /** Unique submission ID for retry tracking through completions. */
+  submissionId?: string;
+  /**
+   * Distributed tracing metadata for SDK logs.
+   *
+   * The current canton-node-sdk submit-and-wait schema does not expose a
+   * submit-level traceContext field, so this is intentionally not forwarded to
+   * the ledger request yet.
+   */
+  traceContext?: CommandTraceContext;
+}
+
+export interface SdkLogger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+}
+
+export interface SdkMetrics {
+  commandSubmitted(templateId: string, choice: string): void;
+  commandSucceeded(templateId: string, choice: string, durationMs: number): void;
+  commandFailed(templateId: string, choice: string, errorType: string): void;
+}
+
+export interface OcpObservabilityOptions {
+  logger?: SdkLogger;
+  metrics?: SdkMetrics;
+  defaultContext?: Partial<CommandContext>;
+}
+
+export interface CommandObservabilityOptions extends OcpObservabilityOptions {
+  context?: CommandContext;
+}
+
+export interface CommandTelemetry {
+  operation: string;
+  templateId?: string;
+  choice?: string;
+}
+
+export function mergeCommandContext(
+  ...contexts: Array<Partial<CommandContext> | undefined>
+): CommandContext | undefined {
+  const merged: CommandContext = {};
+
+  for (const context of contexts) {
+    if (!context) continue;
+    if (context.workflowId !== undefined) merged.workflowId = context.workflowId;
+    if (context.commandId !== undefined) merged.commandId = context.commandId;
+    if (context.submissionId !== undefined) merged.submissionId = context.submissionId;
+    if (context.traceContext !== undefined) merged.traceContext = context.traceContext;
+  }
+
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+export function applyCommandContext<T extends SubmitTransactionTreeParams>(
+  params: T,
+  options?: CommandObservabilityOptions
+): T {
+  const context = mergeCommandContext(options?.defaultContext, options?.context);
+  if (!context) return params;
+
+  return {
+    ...params,
+    ...(context.workflowId !== undefined ? { workflowId: context.workflowId } : {}),
+    ...(context.commandId !== undefined ? { commandId: context.commandId } : {}),
+    ...(context.submissionId !== undefined ? { submissionId: context.submissionId } : {}),
+  };
+}
+
+export async function submitObservedTransactionTree(
+  client: LedgerJsonApiClient,
+  params: SubmitTransactionTreeParams,
+  options: CommandObservabilityOptions | undefined,
+  telemetry: CommandTelemetry
+): Promise<SubmitTransactionTreeResponse> {
+  const submitParams = applyCommandContext(params, options);
+  const context = mergeCommandContext(options?.defaultContext, options?.context);
+  const startedAt = Date.now();
+  const templateId = telemetry.templateId ?? 'unknown';
+  const choice = telemetry.choice ?? 'unknown';
+  const logContext: Record<string, unknown> = {
+    operation: telemetry.operation,
+    templateId,
+    choice,
+    workflowId: submitParams.workflowId,
+    commandId: submitParams.commandId,
+    submissionId: submitParams.submissionId,
+    traceContext: context?.traceContext,
+  };
+
+  options?.logger?.debug('Submitting Canton command', logContext);
+  options?.metrics?.commandSubmitted(templateId, choice);
+
+  try {
+    const response = await client.submitAndWaitForTransactionTree(submitParams);
+    const durationMs = Date.now() - startedAt;
+    options?.logger?.info('Canton command succeeded', {
+      ...logContext,
+      updateId: response.transactionTree.updateId,
+      durationMs,
+    });
+    options?.metrics?.commandSucceeded(templateId, choice, durationMs);
+    return response;
+  } catch (error) {
+    const durationMs = Date.now() - startedAt;
+    const errorType = error instanceof Error ? error.name : typeof error;
+    options?.logger?.error('Canton command failed', {
+      ...logContext,
+      durationMs,
+      errorType,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+    options?.metrics?.commandFailed(templateId, choice, errorType);
+    throw error;
+  }
+}

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,4 +1,4 @@
-import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api';
+import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
 
 type SubmitTransactionTreeParams = Parameters<LedgerJsonApiClient['submitAndWaitForTransactionTree']>[0];
 type SubmitTransactionTreeResponse = Awaited<ReturnType<LedgerJsonApiClient['submitAndWaitForTransactionTree']>>;
@@ -84,9 +84,11 @@ function applyMergedCommandContext<T extends SubmitTransactionTreeParams>(
   };
 }
 
-function runBestEffort(callback: (() => void) | undefined): void {
+function runBestEffort(callback: (() => unknown) | undefined): void {
   try {
-    callback?.();
+    void Promise.resolve(callback?.()).catch(() => {
+      // Observability hooks must not change ledger command outcomes.
+    });
   } catch {
     // Observability hooks must not change ledger command outcomes.
   }

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,5 +1,4 @@
-import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
-import type { TraceContext } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/schemas/common';
+import type { LedgerJsonApiClient, TraceContext } from '@fairmint/canton-node-sdk';
 
 type SubmitTransactionTreeParams = Parameters<LedgerJsonApiClient['submitAndWaitForTransactionTree']>[0];
 type SubmitTransactionTreeResponse = Awaited<ReturnType<LedgerJsonApiClient['submitAndWaitForTransactionTree']>>;

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -84,6 +84,14 @@ function applyMergedCommandContext<T extends SubmitTransactionTreeParams>(
   };
 }
 
+function runBestEffort(callback: (() => void) | undefined): void {
+  try {
+    callback?.();
+  } catch {
+    // Observability hooks must not change ledger command outcomes.
+  }
+}
+
 export function applyCommandContext<T extends SubmitTransactionTreeParams>(
   params: T,
   options?: CommandObservabilityOptions
@@ -113,29 +121,33 @@ export async function submitObservedTransactionTree(
     traceContext: context?.traceContext,
   };
 
-  options?.logger?.debug('Submitting Canton command', logContext);
-  options?.metrics?.commandSubmitted(templateId, choice);
+  runBestEffort(() => options?.logger?.debug('Submitting Canton command', logContext));
+  runBestEffort(() => options?.metrics?.commandSubmitted(templateId, choice));
 
   try {
     const response = await client.submitAndWaitForTransactionTree(submitParams);
     const durationMs = Date.now() - startedAt;
-    options?.logger?.info('Canton command succeeded', {
-      ...logContext,
-      updateId: response.transactionTree.updateId,
-      durationMs,
-    });
-    options?.metrics?.commandSucceeded(templateId, choice, durationMs);
+    runBestEffort(() =>
+      options?.logger?.info('Canton command succeeded', {
+        ...logContext,
+        updateId: response.transactionTree.updateId,
+        durationMs,
+      })
+    );
+    runBestEffort(() => options?.metrics?.commandSucceeded(templateId, choice, durationMs));
     return response;
   } catch (error) {
     const durationMs = Date.now() - startedAt;
     const errorType = error instanceof Error ? error.name : typeof error;
-    options?.logger?.error('Canton command failed', {
-      ...logContext,
-      durationMs,
-      errorType,
-      errorMessage: error instanceof Error ? error.message : String(error),
-    });
-    options?.metrics?.commandFailed(templateId, choice, errorType);
+    runBestEffort(() =>
+      options?.logger?.error('Canton command failed', {
+        ...logContext,
+        durationMs,
+        errorType,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      })
+    );
+    runBestEffort(() => options?.metrics?.commandFailed(templateId, choice, errorType));
     throw error;
   }
 }

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -70,11 +70,10 @@ export function mergeCommandContext(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
-export function applyCommandContext<T extends SubmitTransactionTreeParams>(
+function applyMergedCommandContext<T extends SubmitTransactionTreeParams>(
   params: T,
-  options?: CommandObservabilityOptions
+  context: CommandContext | undefined
 ): T {
-  const context = mergeCommandContext(options?.defaultContext, options?.context);
   if (!context) return params;
 
   return {
@@ -85,14 +84,22 @@ export function applyCommandContext<T extends SubmitTransactionTreeParams>(
   };
 }
 
+export function applyCommandContext<T extends SubmitTransactionTreeParams>(
+  params: T,
+  options?: CommandObservabilityOptions
+): T {
+  const context = mergeCommandContext(options?.defaultContext, options?.context);
+  return applyMergedCommandContext(params, context);
+}
+
 export async function submitObservedTransactionTree(
   client: LedgerJsonApiClient,
   params: SubmitTransactionTreeParams,
   options: CommandObservabilityOptions | undefined,
   telemetry: CommandTelemetry
 ): Promise<SubmitTransactionTreeResponse> {
-  const submitParams = applyCommandContext(params, options);
   const context = mergeCommandContext(options?.defaultContext, options?.context);
+  const submitParams = applyMergedCommandContext(params, context);
   const startedAt = Date.now();
   const templateId = telemetry.templateId ?? 'unknown';
   const choice = telemetry.choice ?? 'unknown';

--- a/test/batch/CapTableBatch.test.ts
+++ b/test/batch/CapTableBatch.test.ts
@@ -547,9 +547,9 @@ describe('CapTableBatch', () => {
           workflowId: 'workflow-default',
           commandId: 'context-command-1',
           submissionId: 'submission-1',
+          traceContext: { traceId: 'trace-1', spanId: 'span-1' },
         })
       );
-      expect(mockClient.submitAndWaitForTransactionTree.mock.calls[0]?.[0]).not.toHaveProperty('traceContext');
       expect(logger.debug).toHaveBeenCalledWith(
         'Submitting Canton command',
         expect.objectContaining({

--- a/test/batch/CapTableBatch.test.ts
+++ b/test/batch/CapTableBatch.test.ts
@@ -487,6 +487,81 @@ describe('CapTableBatch', () => {
       );
     });
 
+    it('should pass command context and emit observability hooks when executing', async () => {
+      const mockClient = {
+        submitAndWaitForTransactionTree: jest.fn().mockResolvedValue({
+          transactionTree: {
+            updateId: 'update-123',
+            eventsById: {
+              'event-1': {
+                ExercisedTreeEvent: {
+                  value: {
+                    choice: 'UpdateCapTable',
+                    exerciseResult: {
+                      updatedCapTableCid: 'cap-table-updated',
+                      createdCids: [],
+                      editedCids: [],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      };
+      const logger = {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      };
+      const metrics = {
+        commandSubmitted: jest.fn(),
+        commandSucceeded: jest.fn(),
+        commandFailed: jest.fn(),
+      };
+
+      const batch = new CapTableBatch(
+        {
+          capTableContractId: 'cap-table-123',
+          actAs: ['party-1'],
+          defaultContext: { workflowId: 'workflow-default' },
+          context: {
+            commandId: 'context-command-1',
+            submissionId: 'submission-1',
+            traceContext: { traceId: 'trace-1', spanId: 'span-1' },
+          },
+          logger,
+          metrics,
+        },
+        mockClient as never
+      );
+
+      batch.delete('document', 'doc-123');
+
+      const result = await batch.execute();
+
+      expect(result.updateId).toBe('update-123');
+      expect(mockClient.submitAndWaitForTransactionTree).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflowId: 'workflow-default',
+          commandId: 'context-command-1',
+          submissionId: 'submission-1',
+        })
+      );
+      expect(mockClient.submitAndWaitForTransactionTree.mock.calls[0]?.[0]).not.toHaveProperty('traceContext');
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Submitting Canton command',
+        expect.objectContaining({
+          operation: 'capTable.update',
+          choice: 'UpdateCapTable',
+          traceContext: { traceId: 'trace-1', spanId: 'span-1' },
+        })
+      );
+      expect(metrics.commandSubmitted).toHaveBeenCalledWith(expect.any(String), 'UpdateCapTable');
+      expect(metrics.commandSucceeded).toHaveBeenCalledWith(expect.any(String), 'UpdateCapTable', expect.any(Number));
+    });
+
     it('should throw RESULT_NOT_FOUND with batch context when UpdateCapTable result missing', async () => {
       // Mock a transaction tree that doesn't contain the UpdateCapTable exercised event
       const mockClient = {

--- a/test/batch/CapTableBatch.test.ts
+++ b/test/batch/CapTableBatch.test.ts
@@ -562,6 +562,51 @@ describe('CapTableBatch', () => {
       expect(metrics.commandSucceeded).toHaveBeenCalledWith(expect.any(String), 'UpdateCapTable', expect.any(Number));
     });
 
+    it('should prefer top-level commandId over context command IDs', async () => {
+      const mockClient = {
+        submitAndWaitForTransactionTree: jest.fn().mockResolvedValue({
+          transactionTree: {
+            updateId: 'update-123',
+            eventsById: {
+              'event-1': {
+                ExercisedTreeEvent: {
+                  value: {
+                    choice: 'UpdateCapTable',
+                    exerciseResult: {
+                      updatedCapTableCid: 'cap-table-updated',
+                      createdCids: [],
+                      editedCids: [],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      };
+
+      const batch = new CapTableBatch(
+        {
+          capTableContractId: 'cap-table-123',
+          actAs: ['party-1'],
+          commandId: 'batch-command-1',
+          defaultContext: { commandId: 'default-command-1' },
+          context: { commandId: 'context-command-1' },
+        },
+        mockClient as never
+      );
+
+      batch.delete('document', 'doc-123');
+
+      await batch.execute();
+
+      expect(mockClient.submitAndWaitForTransactionTree).toHaveBeenCalledWith(
+        expect.objectContaining({
+          commandId: 'batch-command-1',
+        })
+      );
+    });
+
     it('should throw RESULT_NOT_FOUND with batch context when UpdateCapTable result missing', async () => {
       // Mock a transaction tree that doesn't contain the UpdateCapTable exercised event
       const mockClient = {

--- a/test/client/OcpClient.test.ts
+++ b/test/client/OcpClient.test.ts
@@ -245,6 +245,44 @@ describe('OcpClient OpenCapTable.issuerAuthorization.authorize', () => {
     );
     expect(mockedAuthorizeIssuer).not.toHaveBeenCalled();
   });
+
+  it('passes client-level observability defaults into authorizeIssuer', async () => {
+    const ledger = createLedgerJsonApiClient(config);
+    const logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const metrics = {
+      commandSubmitted: jest.fn(),
+      commandSucceeded: jest.fn(),
+      commandFailed: jest.fn(),
+    };
+    const ocp = new OcpClient({
+      ledger,
+      logger,
+      metrics,
+      defaultContext: { workflowId: 'workflow-default' },
+    });
+
+    await ocp.OpenCapTable.issuerAuthorization.authorize({
+      issuer: 'issuer::party',
+      context: { commandId: 'command-call' },
+    });
+
+    expect(mockedAuthorizeIssuer).toHaveBeenCalledWith(
+      ledger,
+      expect.objectContaining({
+        issuer: 'issuer::party',
+        logger,
+        metrics,
+        defaultContext: { workflowId: 'workflow-default' },
+        context: { commandId: 'command-call' },
+      })
+    );
+    expect(mockedAuthorizeIssuer).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('OcpClient OpenCapTable.capTable facade', () => {

--- a/test/client/OcpClient.test.ts
+++ b/test/client/OcpClient.test.ts
@@ -283,6 +283,47 @@ describe('OcpClient OpenCapTable.issuerAuthorization.authorize', () => {
     );
     expect(mockedAuthorizeIssuer).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps client-level observability defaults when per-call fields are undefined', async () => {
+    const ledger = createLedgerJsonApiClient(config);
+    const logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const metrics = {
+      commandSubmitted: jest.fn(),
+      commandSucceeded: jest.fn(),
+      commandFailed: jest.fn(),
+    };
+    const ocp = new OcpClient({
+      ledger,
+      logger,
+      metrics,
+      defaultContext: { workflowId: 'workflow-default' },
+    });
+
+    await ocp.OpenCapTable.issuerAuthorization.authorize({
+      issuer: 'issuer::party',
+      logger: undefined,
+      metrics: undefined,
+      defaultContext: undefined,
+      context: { commandId: 'command-call' },
+    });
+
+    expect(mockedAuthorizeIssuer).toHaveBeenCalledWith(
+      ledger,
+      expect.objectContaining({
+        issuer: 'issuer::party',
+        logger,
+        metrics,
+        defaultContext: { workflowId: 'workflow-default' },
+        context: { commandId: 'command-call' },
+      })
+    );
+    expect(mockedAuthorizeIssuer).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('OcpClient OpenCapTable.capTable facade', () => {

--- a/test/functions/factory/createFactory.test.ts
+++ b/test/functions/factory/createFactory.test.ts
@@ -160,9 +160,9 @@ describe('createFactory', () => {
         workflowId: 'workflow-observed',
         commandId: 'cmd-observed',
         submissionId: 'submission-observed',
+        traceContext: { traceId: 'trace-observed', spanId: 'span-observed' },
       })
     );
-    expect(mockClient.submitAndWaitForTransactionTree.mock.calls[0]?.[0]).not.toHaveProperty('traceContext');
     expect(logger.debug).toHaveBeenCalledWith(
       'Submitting Canton command',
       expect.objectContaining({

--- a/test/functions/factory/createFactory.test.ts
+++ b/test/functions/factory/createFactory.test.ts
@@ -106,6 +106,74 @@ describe('createFactory', () => {
     });
   });
 
+  it('passes command context and emits observability hooks', async () => {
+    const factoryTemplateId = OCP_TEMPLATES.ocpFactory;
+    const mockContractId = 'factory-contract-cid';
+    const mockUpdateId = 'update-observed';
+    const logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const metrics = {
+      commandSubmitted: jest.fn(),
+      commandSucceeded: jest.fn(),
+      commandFailed: jest.fn(),
+    };
+
+    mockClient.submitAndWaitForTransactionTree.mockResolvedValue({
+      transactionTree: {
+        updateId: mockUpdateId,
+        commandId: 'cmd-observed',
+        workflowId: 'workflow-observed',
+        offset: 1,
+        eventsById: {
+          e1: {
+            CreatedTreeEvent: {
+              value: {
+                templateId: factoryTemplateId,
+                contractId: mockContractId,
+              },
+            },
+          },
+        },
+        synchronizerId: 'sync-1',
+        recordTime: '2026-02-17T00:00:00Z',
+      },
+    } as unknown as SubmitAndWaitForTransactionTreeResponse);
+
+    await createFactory(mockClient as unknown as LedgerJsonApiClient, {
+      systemOperator,
+      logger,
+      metrics,
+      context: {
+        workflowId: 'workflow-observed',
+        commandId: 'cmd-observed',
+        submissionId: 'submission-observed',
+        traceContext: { traceId: 'trace-observed', spanId: 'span-observed' },
+      },
+    });
+
+    expect(mockClient.submitAndWaitForTransactionTree).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowId: 'workflow-observed',
+        commandId: 'cmd-observed',
+        submissionId: 'submission-observed',
+      })
+    );
+    expect(mockClient.submitAndWaitForTransactionTree.mock.calls[0]?.[0]).not.toHaveProperty('traceContext');
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Submitting Canton command',
+      expect.objectContaining({
+        operation: 'createFactory',
+        traceContext: { traceId: 'trace-observed', spanId: 'span-observed' },
+      })
+    );
+    expect(metrics.commandSubmitted).toHaveBeenCalledWith(factoryTemplateId, 'Create');
+    expect(metrics.commandSucceeded).toHaveBeenCalledWith(factoryTemplateId, 'Create', expect.any(Number));
+  });
+
   it('throws OcpContractError when CreatedTreeEvent is missing', async () => {
     mockClient.submitAndWaitForTransactionTree.mockResolvedValue({
       transactionTree: {

--- a/test/observability/observability.test.ts
+++ b/test/observability/observability.test.ts
@@ -87,6 +87,40 @@ describe('observability helpers', () => {
     expect(metrics.commandFailed).not.toHaveBeenCalled();
   });
 
+  it('logs traceContext provided directly on submit params', async () => {
+    const client = {
+      submitAndWaitForTransactionTree: jest.fn().mockResolvedValue({
+        transactionTree: {
+          updateId: 'update-123',
+        },
+      }),
+    };
+    const logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    await submitObservedTransactionTree(
+      client as never,
+      {
+        commands: [],
+        actAs: ['issuer::party'],
+        traceContext: { traceId: 'trace-from-params', spanId: 'span-from-params' },
+      },
+      { logger },
+      { operation: 'test.operation', templateId: 'template-1', choice: 'Choice' }
+    );
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Submitting Canton command',
+      expect.objectContaining({
+        traceContext: { traceId: 'trace-from-params', spanId: 'span-from-params' },
+      })
+    );
+  });
+
   it('does not let success observability hook failures change command outcomes', async () => {
     const response = {
       transactionTree: {

--- a/test/observability/observability.test.ts
+++ b/test/observability/observability.test.ts
@@ -1,7 +1,7 @@
 import { applyCommandContext, submitObservedTransactionTree } from '../../src/observability';
 
 describe('observability helpers', () => {
-  it('applies ledger-supported command context fields without forwarding traceContext', () => {
+  it('applies command context fields including traceContext', () => {
     const params = {
       commands: [],
       actAs: ['issuer::party'],
@@ -23,8 +23,8 @@ describe('observability helpers', () => {
       workflowId: 'workflow-default',
       commandId: 'command-call',
       submissionId: 'submission-call',
+      traceContext: { traceId: 'trace-1', spanId: 'span-1' },
     });
-    expect(result).not.toHaveProperty('traceContext');
   });
 
   it('emits success logs and metrics around command submission', async () => {
@@ -68,6 +68,7 @@ describe('observability helpers', () => {
         workflowId: 'workflow-1',
         commandId: 'command-1',
         submissionId: 'submission-1',
+        traceContext: { traceId: 'trace-1', spanId: 'span-1' },
       })
     );
     expect(logger.debug).toHaveBeenCalledWith(

--- a/test/observability/observability.test.ts
+++ b/test/observability/observability.test.ts
@@ -109,9 +109,7 @@ describe('observability helpers', () => {
       commandSubmitted: jest.fn(() => {
         throw new Error('submitted failed');
       }),
-      commandSucceeded: jest.fn(() => {
-        throw new Error('succeeded failed');
-      }),
+      commandSucceeded: jest.fn().mockRejectedValue(new Error('succeeded failed')),
       commandFailed: jest.fn(),
     };
 

--- a/test/observability/observability.test.ts
+++ b/test/observability/observability.test.ts
@@ -1,0 +1,88 @@
+import { applyCommandContext, submitObservedTransactionTree } from '../../src/observability';
+
+describe('observability helpers', () => {
+  it('applies ledger-supported command context fields without forwarding traceContext', () => {
+    const params = {
+      commands: [],
+      actAs: ['issuer::party'],
+    };
+
+    const result = applyCommandContext(params as never, {
+      defaultContext: {
+        workflowId: 'workflow-default',
+        commandId: 'command-default',
+      },
+      context: {
+        commandId: 'command-call',
+        submissionId: 'submission-call',
+        traceContext: { traceId: 'trace-1', spanId: 'span-1' },
+      },
+    }) as Record<string, unknown>;
+
+    expect(result).toMatchObject({
+      workflowId: 'workflow-default',
+      commandId: 'command-call',
+      submissionId: 'submission-call',
+    });
+    expect(result).not.toHaveProperty('traceContext');
+  });
+
+  it('emits success logs and metrics around command submission', async () => {
+    const client = {
+      submitAndWaitForTransactionTree: jest.fn().mockResolvedValue({
+        transactionTree: {
+          updateId: 'update-123',
+        },
+      }),
+    };
+    const logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const metrics = {
+      commandSubmitted: jest.fn(),
+      commandSucceeded: jest.fn(),
+      commandFailed: jest.fn(),
+    };
+
+    await submitObservedTransactionTree(
+      client as never,
+      { commands: [], actAs: ['issuer::party'] },
+      {
+        logger,
+        metrics,
+        context: {
+          workflowId: 'workflow-1',
+          commandId: 'command-1',
+          submissionId: 'submission-1',
+          traceContext: { traceId: 'trace-1', spanId: 'span-1' },
+        },
+      },
+      { operation: 'test.operation', templateId: 'template-1', choice: 'Choice' }
+    );
+
+    expect(client.submitAndWaitForTransactionTree).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowId: 'workflow-1',
+        commandId: 'command-1',
+        submissionId: 'submission-1',
+      })
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Submitting Canton command',
+      expect.objectContaining({
+        operation: 'test.operation',
+        traceContext: { traceId: 'trace-1', spanId: 'span-1' },
+      })
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      'Canton command succeeded',
+      expect.objectContaining({ updateId: 'update-123' })
+    );
+    expect(metrics.commandSubmitted).toHaveBeenCalledWith('template-1', 'Choice');
+    expect(metrics.commandSucceeded).toHaveBeenCalledWith('template-1', 'Choice', expect.any(Number));
+    expect(metrics.commandFailed).not.toHaveBeenCalled();
+  });
+});

--- a/test/observability/observability.test.ts
+++ b/test/observability/observability.test.ts
@@ -85,4 +85,79 @@ describe('observability helpers', () => {
     expect(metrics.commandSucceeded).toHaveBeenCalledWith('template-1', 'Choice', expect.any(Number));
     expect(metrics.commandFailed).not.toHaveBeenCalled();
   });
+
+  it('does not let success observability hook failures change command outcomes', async () => {
+    const response = {
+      transactionTree: {
+        updateId: 'update-123',
+      },
+    };
+    const client = {
+      submitAndWaitForTransactionTree: jest.fn().mockResolvedValue(response),
+    };
+    const logger = {
+      debug: jest.fn(() => {
+        throw new Error('debug failed');
+      }),
+      info: jest.fn(() => {
+        throw new Error('info failed');
+      }),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const metrics = {
+      commandSubmitted: jest.fn(() => {
+        throw new Error('submitted failed');
+      }),
+      commandSucceeded: jest.fn(() => {
+        throw new Error('succeeded failed');
+      }),
+      commandFailed: jest.fn(),
+    };
+
+    await expect(
+      submitObservedTransactionTree(
+        client as never,
+        { commands: [], actAs: ['issuer::party'] },
+        { logger, metrics },
+        { operation: 'test.operation', templateId: 'template-1', choice: 'Choice' }
+      )
+    ).resolves.toBe(response);
+
+    expect(client.submitAndWaitForTransactionTree).toHaveBeenCalledTimes(1);
+    expect(metrics.commandFailed).not.toHaveBeenCalled();
+  });
+
+  it('preserves ledger failures when failure observability hooks throw', async () => {
+    const ledgerError = new Error('ledger failed');
+    const client = {
+      submitAndWaitForTransactionTree: jest.fn().mockRejectedValue(ledgerError),
+    };
+    const logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(() => {
+        throw new Error('error hook failed');
+      }),
+    };
+    const metrics = {
+      commandSubmitted: jest.fn(),
+      commandSucceeded: jest.fn(),
+      commandFailed: jest.fn(() => {
+        throw new Error('failed hook failed');
+      }),
+    };
+
+    await expect(
+      submitObservedTransactionTree(
+        client as never,
+        { commands: [], actAs: ['issuer::party'] },
+        { logger, metrics },
+        { operation: 'test.operation', templateId: 'template-1', choice: 'Choice' }
+      )
+    ).rejects.toBe(ledgerError);
+
+    expect(metrics.commandFailed).toHaveBeenCalledWith('template-1', 'Choice', 'Error');
+  });
 });


### PR DESCRIPTION
## Summary

Implements ENG-455 write-operation observability for OCP Canton submissions:

- exports `CommandContext`, `SdkLogger`, `SdkMetrics`, and observed submit helpers
- forwards `workflowId`, `commandId`, `submissionId`, and `traceContext` into Canton command submissions
- wires logger/metrics/default context through `OcpClient` and direct write helpers (`CapTableBatch`, cap-table archive, factory create, issuer authorization/withdraw)
- consumes published `@fairmint/canton-node-sdk@0.0.207`, which includes submit-level `traceContext` support from Fairmint/canton-node-sdk#342
- keeps durable observability docs in the GitHub Wiki instead of README

## Validation

- `npm run fix`
- `npm run build`
- `npm run test:ci` (53 suites / 1673 tests)
- `git diff --check`

Linear: ENG-455

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all primary OCP write submission paths and raises the canton-node-sdk peer floor; behavior should be unchanged when hooks are omitted, but misconfigured context or logger/metrics implementations could affect operators integrating tracing.
> 
> **Overview**
> Adds a new **`observability`** layer for Canton write submissions: **`CommandContext`** (`workflowId`, `commandId`, `submissionId`, **`traceContext`**), optional **`SdkLogger`** / **`SdkMetrics`**, and **`submitObservedTransactionTree`** that merges context, forwards fields to the ledger, and emits best-effort logs/metrics without changing success/failure outcomes.
> 
> **`OcpClient`** now accepts observability on construction (`logger`, `metrics`, `defaultContext`), exposes **`observability`**, and merges defaults into issuer authorization, withdraw, **`CapTableBatch`**, and cap-table archive via **`withObservability`**. The same options extend write param types on **`CapTableBatch`**, **`archiveCapTable`**, **`createFactory`**, **`authorizeIssuer`**, and **`withdrawAuthorization`**, which route submits through the observed helper instead of calling the ledger directly. **`CapTableBatch.execute`** documents **`commandId`** precedence (top-level over context/default) when building the final command ID.
> 
> Public API exports observability types from **`src/index.ts`**. **`@fairmint/canton-node-sdk`** is bumped to **0.0.207** (dev + peer `>=0.0.207`) for submit-level **`traceContext`**. Tests cover context merging, hook behavior, client default forwarding, and batch command-ID precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4463a10e1c8111872a1ec47758290a8550f1e2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced command operation tracking with context support (workflow ID, command ID, submission ID, trace context)
  * Added logging and metrics hooks for improved visibility into transaction operations

* **Bug Fixes**
  * Fixed handling of undefined event blob fields in cap table transactions

* **Chores**
  * Updated SDK dependency version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->