### PR TITLE
[codex] Add OCP environment configuration helpers

### DIFF
--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -56,8 +56,17 @@
  * @module
  */
 
-import type { LedgerJsonApiClient, ValidatorApiClient } from '@fairmint/canton-node-sdk';
+import { Canton, type LedgerJsonApiClient, type ValidatorApiClient } from '@fairmint/canton-node-sdk';
 import { TransactionBatch } from '@fairmint/canton-node-sdk/build/src/utils/transactions';
+import {
+  loadEnvironmentConfigFromEnv,
+  resolveEnvironmentConfig,
+  toCantonNetwork,
+  toResolvedCantonConfig,
+  type EnvironmentConfig,
+  type EnvironmentConfigInput,
+  type OcpEnvironment,
+} from './environment';
 import { OcpErrorCodes, OcpValidationError } from './errors';
 import {
   authorizeIssuer,
@@ -408,6 +417,11 @@ export class OcpClient {
    */
   public readonly factory?: OcpFactoryCoordinates;
 
+  /** Logical Canton environment when this client was created through environment helpers. */
+  public readonly environment?: OcpEnvironment;
+
+  private productionSafetyChecksEnabled: boolean;
+
   /**
    * Context manager for caching commonly used values.
    *
@@ -424,11 +438,86 @@ export class OcpClient {
    * **`validator`** — optional when using cap-table-only APIs from this package.
    */
   constructor(dependencies: OcpClientDependencies) {
+    validateInjectedEnvironment(dependencies.environment, dependencies.ledger);
+    validateFactoryCoordinates(dependencies.factory);
     this.ledger = dependencies.ledger;
     this.validator = dependencies.validator;
-    this.factory = dependencies.factory === undefined ? undefined : { ...dependencies.factory };
+    this.factory =
+      dependencies.factory === undefined
+        ? undefined
+        : { contractId: dependencies.factory.contractId, templateId: dependencies.factory.templateId };
+    this.environment = dependencies.environment;
+    this.productionSafetyChecksEnabled = dependencies.productionSafetyChecks ?? false;
 
     this.OpenCapTable = this.createOpenCapTableMethods();
+  }
+
+  /**
+   * Create an OCP client from an environment config.
+   *
+   * This is an opt-in convenience around `@fairmint/canton-node-sdk`'s `Canton` client. The constructor still accepts
+   * injected `ledger` / `validator` clients for callers that manage runtime clients themselves.
+   */
+  public static create(options: OcpClientEnvironmentOptions): OcpClient {
+    return OcpClient.fromEnvironment(options);
+  }
+
+  /** Create a client using the LocalNet preset, including cn-quickstart app-provider ports. */
+  public static forLocalNet(options: OcpClientPresetOptions = {}): OcpClient {
+    return OcpClient.fromEnvironment({ ...options, environment: 'localnet' });
+  }
+
+  /** Create a client for DevNet with explicit API URLs and OAuth2 credentials. */
+  public static forDevNet(options: OcpClientHostedPresetOptions): OcpClient {
+    return OcpClient.fromEnvironment({ ...options, environment: 'devnet' });
+  }
+
+  /** Create a client for TestNet with explicit API URLs and OAuth2 credentials. */
+  public static forTestNet(options: OcpClientHostedPresetOptions): OcpClient {
+    return OcpClient.fromEnvironment({ ...options, environment: 'testnet' });
+  }
+
+  /** Create a client for MainNet with explicit API URLs and OAuth2 credentials. */
+  public static forMainNet(options: OcpClientHostedPresetOptions): OcpClient {
+    return OcpClient.fromEnvironment({ ...options, environment: 'mainnet' });
+  }
+
+  /** Create a client from `CANTON_*` environment variables, with optional per-call overrides. */
+  public static fromEnv(options: OcpClientEnvOptions = {}): OcpClient {
+    const { factory, productionSafetyChecks, ...overrides } = options;
+    const config = loadEnvironmentConfigFromEnv(process.env, overrides);
+    return OcpClient.fromEnvironment({ ...config, factory, productionSafetyChecks });
+  }
+
+  private static fromEnvironment(options: OcpClientEnvironmentOptions): OcpClient {
+    const { factory, productionSafetyChecks, ...environmentInput } = options;
+    const environmentConfig = resolveEnvironmentConfig(environmentInput);
+    const canton = new Canton(toResolvedCantonConfig(environmentConfig));
+
+    return new OcpClient({
+      ledger: canton.ledger,
+      validator: canton.validator,
+      factory,
+      environment: environmentConfig.environment,
+      productionSafetyChecks,
+    });
+  }
+
+  public isLocalNet(): boolean {
+    return this.environment === 'localnet';
+  }
+
+  public isProduction(): boolean {
+    return this.environment === 'mainnet';
+  }
+
+  public setProductionSafetyChecks(enabled = true): this {
+    this.productionSafetyChecksEnabled = enabled;
+    return this;
+  }
+
+  public areProductionSafetyChecksEnabled(): boolean {
+    return this.productionSafetyChecksEnabled;
   }
 
   /**
@@ -743,13 +832,27 @@ export class OcpClient {
       issuerAuthorization: {
         authorize: async (params: AuthorizeIssuerParams) => {
           const hasPerCallOverride = params.factoryContractId != null || params.factoryTemplateId != null;
+          const clientFactory = hasCompleteFactoryCoordinates(this.factory) ? this.factory : undefined;
+          if (!hasPerCallOverride && this.factory !== undefined && clientFactory === undefined) {
+            throw new OcpValidationError('factory', 'factory override must include contractId and templateId', {
+              code: OcpErrorCodes.REQUIRED_FIELD_MISSING,
+            });
+          }
+          if (!hasPerCallOverride && clientFactory === undefined && requiresExplicitFactory(this.environment)) {
+            throw new OcpValidationError(
+              'factory',
+              `factory override is required for ${this.environment} issuer authorization`,
+              { code: OcpErrorCodes.REQUIRED_FIELD_MISSING }
+            );
+          }
+
           return authorizeIssuer(client, {
             ...params,
             ...(hasPerCallOverride
               ? {}
               : {
-                  factoryContractId: this.factory?.contractId,
-                  factoryTemplateId: this.factory?.templateId,
+                  factoryContractId: clientFactory?.contractId,
+                  factoryTemplateId: clientFactory?.templateId,
                 }),
           });
         },
@@ -791,6 +894,67 @@ export interface OcpClientDependencies {
    * If omitted, the SDK resolves factory coords from the bundled network config.
    */
   readonly factory?: OcpFactoryCoordinates;
+  readonly environment?: OcpEnvironment;
+  readonly productionSafetyChecks?: boolean;
+}
+
+export type OcpClientEnvironmentOptions = EnvironmentConfigInput & {
+  readonly factory?: OcpFactoryCoordinates;
+  readonly productionSafetyChecks?: boolean;
+};
+
+export type OcpClientPresetOptions = Omit<Partial<EnvironmentConfigInput>, 'environment'> & {
+  readonly factory?: OcpFactoryCoordinates;
+  readonly productionSafetyChecks?: boolean;
+};
+
+export type OcpClientHostedPresetOptions = OcpClientPresetOptions &
+  Required<Pick<EnvironmentConfig, 'ledgerApiUrl' | 'authUrl' | 'clientId' | 'clientSecret'>>;
+
+export type OcpClientEnvOptions = Partial<EnvironmentConfigInput> & {
+  readonly factory?: OcpFactoryCoordinates;
+  readonly productionSafetyChecks?: boolean;
+};
+
+function requiresExplicitFactory(environment: OcpEnvironment | undefined): boolean {
+  return environment === 'localnet' || environment === 'custom' || environment === 'scratchnet';
+}
+
+function hasCompleteFactoryCoordinates(factory: OcpFactoryCoordinates | undefined): factory is OcpFactoryCoordinates {
+  return (
+    typeof factory?.contractId === 'string' &&
+    factory.contractId.trim().length > 0 &&
+    typeof factory.templateId === 'string' &&
+    factory.templateId.trim().length > 0
+  );
+}
+
+function validateFactoryCoordinates(factory: OcpFactoryCoordinates | undefined): void {
+  if (factory !== undefined && !hasCompleteFactoryCoordinates(factory)) {
+    throw new OcpValidationError('factory', 'factory override must include contractId and templateId', {
+      code: OcpErrorCodes.REQUIRED_FIELD_MISSING,
+    });
+  }
+}
+
+function validateInjectedEnvironment(environment: OcpEnvironment | undefined, ledger: LedgerJsonApiClient): void {
+  if (environment === undefined) {
+    return;
+  }
+
+  const ledgerNetwork = ledger.getNetwork();
+  const expectedNetwork = toCantonNetwork(environment);
+  if (ledgerNetwork !== expectedNetwork) {
+    throw new OcpValidationError(
+      'environment',
+      `environment ${environment} does not match ledger network ${ledgerNetwork}`,
+      {
+        code: OcpErrorCodes.INVALID_FORMAT,
+        expectedType: expectedNetwork,
+        receivedValue: ledgerNetwork,
+      }
+    );
+  }
 }
 
 /** Parameters for creating a batch cap table update */

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,0 +1,465 @@
+import type { ApiConfig, AuthConfig, CantonConfig, NetworkType } from '@fairmint/canton-node-sdk';
+import { createHmac } from 'crypto';
+
+export type OcpEnvironment = 'localnet' | 'scratchnet' | 'devnet' | 'testnet' | 'mainnet' | 'custom';
+export type OcpAuthMode = 'shared-secret' | 'oauth2';
+
+export interface EnvironmentConfig {
+  environment: OcpEnvironment;
+  ledgerApiUrl: string;
+  validatorApiUrl?: string;
+  scanApiUrl?: string;
+  authMode: OcpAuthMode;
+  authUrl?: string;
+  clientId?: string;
+  clientSecret?: string;
+  sharedSecret?: string;
+  provider?: string;
+  partyId?: string;
+  party?: string;
+  userId?: string;
+  managedParties?: string[];
+  audience?: string;
+  scope?: string;
+  debug?: boolean;
+}
+
+export type EnvironmentConfigInput = Partial<EnvironmentConfig> & Pick<EnvironmentConfig, 'environment'>;
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+export type EnvironmentPreset = Partial<EnvironmentConfig> & Pick<EnvironmentConfig, 'environment' | 'authMode'>;
+type EnvironmentConfigCandidateInput = Omit<Partial<EnvironmentConfig>, 'environment' | 'authMode'> & {
+  environment: string;
+  authMode?: string;
+};
+type EnvironmentConfigCandidate = Omit<Partial<EnvironmentConfig>, 'environment' | 'authMode'> & {
+  environment: string;
+  authMode?: string;
+};
+
+export const LOCALNET_PRESET: EnvironmentPreset = {
+  environment: 'localnet',
+  ledgerApiUrl: 'http://localhost:3975',
+  validatorApiUrl: 'http://localhost:3903',
+  scanApiUrl: 'http://localhost:4000/api/scan',
+  authMode: 'shared-secret',
+  provider: 'app-provider',
+  clientId: 'ocp-sdk',
+  sharedSecret: 'unsafe',
+};
+
+export const SCRATCHNET_PRESET: EnvironmentPreset = {
+  environment: 'scratchnet',
+  authMode: 'oauth2',
+};
+
+export const DEVNET_PRESET: EnvironmentPreset = {
+  environment: 'devnet',
+  authMode: 'oauth2',
+};
+
+export const TESTNET_PRESET: EnvironmentPreset = {
+  environment: 'testnet',
+  authMode: 'oauth2',
+};
+
+export const MAINNET_PRESET: EnvironmentPreset = {
+  environment: 'mainnet',
+  authMode: 'oauth2',
+};
+
+export const CUSTOM_PRESET: EnvironmentPreset = {
+  environment: 'custom',
+  authMode: 'oauth2',
+};
+
+export const ENVIRONMENT_PRESETS: Record<OcpEnvironment, EnvironmentPreset> = {
+  localnet: LOCALNET_PRESET,
+  scratchnet: SCRATCHNET_PRESET,
+  devnet: DEVNET_PRESET,
+  testnet: TESTNET_PRESET,
+  mainnet: MAINNET_PRESET,
+  custom: CUSTOM_PRESET,
+};
+
+const ENVIRONMENTS = Object.keys(ENVIRONMENT_PRESETS) as OcpEnvironment[];
+const AUTH_MODES: OcpAuthMode[] = ['shared-secret', 'oauth2'];
+
+function isOcpEnvironment(value: string): value is OcpEnvironment {
+  return ENVIRONMENTS.includes(value as OcpEnvironment);
+}
+
+function isOcpAuthMode(value: string): value is OcpAuthMode {
+  return AUTH_MODES.includes(value as OcpAuthMode);
+}
+
+function parseOcpEnvironment(value: string): OcpEnvironment {
+  const normalized = value.toLowerCase();
+  if (!isOcpEnvironment(normalized)) {
+    throw new Error(
+      `Invalid Canton environment configuration: Unsupported Canton environment: ${value}. Expected one of: ${ENVIRONMENTS.join(', ')}`
+    );
+  }
+  return normalized;
+}
+
+function envValue(env: Record<string, string | undefined>, ...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = env[name];
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+}
+
+function parseManagedParties(value: string | undefined): string[] | undefined {
+  const parties = value
+    ?.split(',')
+    .map((party) => party.trim())
+    .filter((party) => party.length > 0);
+  return parties && parties.length > 0 ? parties : undefined;
+}
+
+function isLocalUrl(url: string | undefined): boolean {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return ['localhost', '127.0.0.1', '::1'].includes(parsed.hostname) || parsed.hostname.endsWith('.localhost');
+  } catch {
+    return false;
+  }
+}
+
+function isBlank(value: string | undefined): boolean {
+  return value === undefined || value.trim() === '';
+}
+
+function trimOptionalString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function firstNonBlank(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = trimOptionalString(value);
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+function trimManagedParties(managedParties: string[] | undefined): string[] | undefined {
+  const trimmed = managedParties
+    ?.map((party) => trimOptionalString(party))
+    .filter((party): party is string => party !== undefined);
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function urlEnvironmentTokens(url: string): Set<string> {
+  try {
+    const parsed = new URL(url.toLowerCase());
+    return new Set(`${parsed.hostname} ${parsed.pathname}`.split(/[^a-z0-9]+/).filter(Boolean));
+  } catch {
+    return new Set(
+      url
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter(Boolean)
+    );
+  }
+}
+
+function omitUndefined<T extends object>(input: T): Partial<T> {
+  return Object.fromEntries(Object.entries(input).filter(([, value]) => value !== undefined)) as Partial<T>;
+}
+
+function configWithPreset(input: EnvironmentConfigCandidateInput): EnvironmentConfigCandidate {
+  const preset: Partial<EnvironmentConfig> = isOcpEnvironment(input.environment)
+    ? ENVIRONMENT_PRESETS[input.environment]
+    : {};
+  const definedInput = omitUndefined(input);
+  return {
+    ...preset,
+    ...definedInput,
+    environment: input.environment,
+    partyId: firstNonBlank(input.partyId, input.party, preset.partyId, preset.party),
+  };
+}
+
+export function validateConfig(input: EnvironmentConfigCandidateInput): ValidationResult {
+  const config = configWithPreset(input);
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!isOcpEnvironment(config.environment)) {
+    errors.push(`Unsupported Canton environment: ${String(config.environment)}`);
+  }
+
+  if (isBlank(config.ledgerApiUrl)) {
+    errors.push('ledgerApiUrl is required. Set it explicitly or provide CANTON_LEDGER_API_URL.');
+  }
+
+  const detectedEnvironment = config.ledgerApiUrl ? detectEnvironment(config.ledgerApiUrl) : undefined;
+  if (
+    detectedEnvironment !== undefined &&
+    detectedEnvironment !== 'custom' &&
+    config.environment !== 'custom' &&
+    detectedEnvironment !== config.environment
+  ) {
+    errors.push(`ledgerApiUrl appears to target ${detectedEnvironment}, but environment is ${config.environment}.`);
+  }
+
+  if (config.authMode === undefined || !isOcpAuthMode(config.authMode)) {
+    errors.push(`authMode must be one of: ${AUTH_MODES.join(', ')}`);
+  }
+
+  if (config.authMode === 'oauth2') {
+    if (isBlank(config.authUrl)) {
+      errors.push('authUrl is required for oauth2 auth mode.');
+    }
+    if (isBlank(config.clientId)) {
+      errors.push('clientId is required for oauth2 auth mode.');
+    }
+    if (isBlank(config.clientSecret)) {
+      errors.push('clientSecret is required for oauth2 auth mode.');
+    }
+  }
+
+  if (config.authMode === 'shared-secret') {
+    if (config.environment === 'mainnet') {
+      errors.push('shared-secret auth mode is not allowed for mainnet.');
+    }
+    if (config.environment !== 'localnet' && isBlank(config.sharedSecret)) {
+      errors.push('sharedSecret is required for shared-secret auth mode outside localnet.');
+    }
+  }
+
+  if (config.environment === 'localnet') {
+    for (const [name, url] of [
+      ['ledgerApiUrl', config.ledgerApiUrl],
+      ['validatorApiUrl', config.validatorApiUrl],
+      ['scanApiUrl', config.scanApiUrl],
+    ] as const) {
+      if (url && !isLocalUrl(url)) {
+        warnings.push(`${name} is not a localhost URL for localnet.`);
+      }
+    }
+  }
+
+  if (['devnet', 'testnet', 'mainnet'].includes(config.environment) && isLocalUrl(config.ledgerApiUrl)) {
+    warnings.push(`${config.environment} ledgerApiUrl points at localhost.`);
+  }
+
+  if (config.environment === 'mainnet') {
+    warnings.push('mainnet configuration targets production Canton services.');
+  }
+
+  if (config.validatorApiUrl === undefined) {
+    warnings.push('validatorApiUrl is not set; validator-backed helpers will rely on Canton defaults if available.');
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+export function resolveEnvironmentConfig(input: EnvironmentConfigCandidateInput): EnvironmentConfig {
+  const config = configWithPreset(input);
+  const result = validateConfig(config);
+
+  if (!result.valid) {
+    throw new Error(`Invalid Canton environment configuration: ${result.errors.join('; ')}`);
+  }
+
+  return {
+    environment: config.environment as OcpEnvironment,
+    ledgerApiUrl: trimOptionalString(config.ledgerApiUrl) as string,
+    validatorApiUrl: trimOptionalString(config.validatorApiUrl),
+    scanApiUrl: trimOptionalString(config.scanApiUrl),
+    authMode: config.authMode as OcpAuthMode,
+    authUrl: trimOptionalString(config.authUrl),
+    clientId: trimOptionalString(config.clientId),
+    clientSecret: trimOptionalString(config.clientSecret),
+    sharedSecret: trimOptionalString(config.sharedSecret),
+    provider: trimOptionalString(config.provider),
+    partyId: trimOptionalString(config.partyId),
+    party: trimOptionalString(config.party),
+    userId: trimOptionalString(config.userId),
+    managedParties: trimManagedParties(config.managedParties),
+    audience: trimOptionalString(config.audience),
+    scope: trimOptionalString(config.scope),
+    debug: config.debug,
+  };
+}
+
+export function detectEnvironment(ledgerApiUrl: string): OcpEnvironment {
+  if (isLocalUrl(ledgerApiUrl)) {
+    return 'localnet';
+  }
+
+  const tokens = urlEnvironmentTokens(ledgerApiUrl);
+  if (tokens.has('scratchnet') || tokens.has('scratch')) {
+    return 'scratchnet';
+  }
+  if (tokens.has('devnet')) {
+    return 'devnet';
+  }
+  if (tokens.has('testnet')) {
+    return 'testnet';
+  }
+  if (tokens.has('mainnet')) {
+    return 'mainnet';
+  }
+
+  return 'custom';
+}
+
+export function loadEnvironmentConfigFromEnv(
+  env: Record<string, string | undefined> = process.env,
+  overrides: Partial<EnvironmentConfigInput> = {}
+): EnvironmentConfig {
+  const ledgerApiUrl = overrides.ledgerApiUrl ?? envValue(env, 'CANTON_LEDGER_API_URL', 'CANTON_LEDGER_JSON_API_URL');
+  const rawEnvironment =
+    overrides.environment ?? envValue(env, 'CANTON_ENVIRONMENT', 'CANTON_CURRENT_NETWORK') ?? undefined;
+  const environment = rawEnvironment
+    ? parseOcpEnvironment(rawEnvironment)
+    : ledgerApiUrl
+      ? detectEnvironment(ledgerApiUrl)
+      : 'localnet';
+  const rawAuthMode = overrides.authMode ?? envValue(env, 'CANTON_AUTH_MODE');
+  const normalizedAuthMode = rawAuthMode?.toLowerCase();
+  const authMode = normalizedAuthMode;
+
+  return resolveEnvironmentConfig({
+    environment,
+    ledgerApiUrl,
+    validatorApiUrl: overrides.validatorApiUrl ?? envValue(env, 'CANTON_VALIDATOR_API_URL', 'CANTON_VALIDATOR_API_URI'),
+    scanApiUrl: overrides.scanApiUrl ?? envValue(env, 'CANTON_SCAN_API_URL', 'CANTON_SCAN_API_URI'),
+    authMode,
+    authUrl: overrides.authUrl ?? envValue(env, 'CANTON_AUTH_URL'),
+    clientId: overrides.clientId ?? envValue(env, 'CANTON_CLIENT_ID'),
+    clientSecret: overrides.clientSecret ?? envValue(env, 'CANTON_CLIENT_SECRET'),
+    sharedSecret: overrides.sharedSecret ?? envValue(env, 'CANTON_SHARED_SECRET'),
+    provider: overrides.provider ?? envValue(env, 'CANTON_PROVIDER', 'CANTON_CURRENT_PROVIDER'),
+    partyId: overrides.partyId ?? overrides.party ?? envValue(env, 'CANTON_PARTY_ID', 'CANTON_PARTY'),
+    userId: overrides.userId ?? envValue(env, 'CANTON_USER_ID'),
+    managedParties: overrides.managedParties ?? parseManagedParties(envValue(env, 'CANTON_MANAGED_PARTIES')),
+    audience: overrides.audience ?? envValue(env, 'CANTON_AUDIENCE'),
+    scope: overrides.scope ?? envValue(env, 'CANTON_SCOPE'),
+    debug: overrides.debug ?? parseBoolean(envValue(env, 'CANTON_DEBUG')),
+  });
+}
+
+export function toCantonNetwork(environment: OcpEnvironment): NetworkType {
+  if (environment === 'scratchnet' || environment === 'custom') {
+    return 'localnet';
+  }
+  return environment;
+}
+
+function createSharedSecretJwt(sharedSecret: string, audience: string, subject: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({
+      sub: subject,
+      aud: audience,
+      iat: now,
+      exp: now + 2 * 60 * 60,
+    })
+  ).toString('base64url');
+  const signature = createHmac('sha256', sharedSecret).update(`${header}.${payload}`).digest('base64url');
+  return `${header}.${payload}.${signature}`;
+}
+
+export function createSharedSecretTokenGenerator(config: EnvironmentConfig): () => Promise<string> {
+  const sharedSecret = config.sharedSecret ?? (config.environment === 'localnet' ? 'unsafe' : undefined);
+  if (!sharedSecret) {
+    throw new Error('sharedSecret is required for shared-secret auth mode outside localnet.');
+  }
+
+  const audience = config.audience ?? 'https://canton.network.global';
+  const subject = config.userId ?? 'ledger-api-user';
+  return async () => {
+    await Promise.resolve();
+    return createSharedSecretJwt(sharedSecret, audience, subject);
+  };
+}
+
+function buildAuthConfig(config: EnvironmentConfig): AuthConfig {
+  if (config.authMode === 'shared-secret') {
+    return {
+      grantType: 'client_credentials',
+      clientId: config.clientId ?? 'ocp-sdk',
+      ...(config.audience ? { audience: config.audience } : {}),
+      ...(config.scope ? { scope: config.scope } : {}),
+      tokenGenerator: createSharedSecretTokenGenerator(config),
+    };
+  }
+
+  return {
+    grantType: 'client_credentials',
+    clientId: config.clientId as string,
+    clientSecret: config.clientSecret,
+    ...(config.audience ? { audience: config.audience } : {}),
+    ...(config.scope ? { scope: config.scope } : {}),
+  };
+}
+
+function apiConfig(apiUrl: string | undefined, auth: AuthConfig, config: EnvironmentConfig): ApiConfig | undefined {
+  if (!apiUrl) {
+    return undefined;
+  }
+
+  return {
+    apiUrl,
+    auth,
+    ...(config.partyId ? { partyId: config.partyId } : {}),
+    ...(config.userId ? { userId: config.userId } : {}),
+  };
+}
+
+export function toResolvedCantonConfig(config: EnvironmentConfig): CantonConfig {
+  const auth = buildAuthConfig(config);
+  const ledger = apiConfig(config.ledgerApiUrl, auth, config);
+  const validator = apiConfig(config.validatorApiUrl, auth, config);
+  const scan = apiConfig(config.scanApiUrl, auth, config);
+
+  return {
+    network: toCantonNetwork(config.environment),
+    ...(config.provider ? { provider: config.provider } : {}),
+    ...(config.authUrl ? { authUrl: config.authUrl } : {}),
+    ...(config.partyId ? { partyId: config.partyId } : {}),
+    ...(config.userId ? { userId: config.userId } : {}),
+    ...(config.managedParties ? { managedParties: config.managedParties } : {}),
+    ...(config.debug !== undefined ? { debug: config.debug } : {}),
+    apis: {
+      ...(ledger ? { LEDGER_JSON_API: ledger } : {}),
+      ...(validator ? { VALIDATOR_API: validator } : {}),
+      ...(scan ? { SCAN_API: scan } : {}),
+    },
+  };
+}
+
+export function toCantonConfig(input: EnvironmentConfigInput): CantonConfig {
+  return toResolvedCantonConfig(resolveEnvironmentConfig(input));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './environment';
 export * from './errors';
 export * from './functions';
 export * from './OcpClient';

--- a/test/client/OcpClient.test.ts
+++ b/test/client/OcpClient.test.ts
@@ -1,4 +1,4 @@
-import type { ClientConfig } from '@fairmint/canton-node-sdk';
+import { Canton, type ClientConfig } from '@fairmint/canton-node-sdk';
 import { Fairmint } from '@fairmint/open-captable-protocol-daml-js';
 import * as openCapTableCapTable from '../../src/functions/OpenCapTable/capTable';
 import {
@@ -8,13 +8,17 @@ import {
 import { OcpClient } from '../../src/OcpClient';
 import { createLedgerAndValidatorClients, createLedgerJsonApiClient } from '../utils/cantonNodeSdkCompat';
 
-jest.mock('@fairmint/canton-node-sdk');
 jest.mock('../../src/functions/OpenCapTable/issuerAuthorization/authorizeIssuer', () => ({
   authorizeIssuer: jest.fn(),
 }));
 
 describe('OcpClient', () => {
   const config: ClientConfig = { network: 'devnet' };
+  const mockedCanton = Canton as unknown as { __instances: Array<{ config: unknown }> };
+
+  beforeEach(() => {
+    mockedCanton.__instances.length = 0;
+  });
 
   it('reuses injected runtime clients instead of constructing hidden ones', () => {
     const { ledger, validator } = createLedgerAndValidatorClients(config);
@@ -41,6 +45,101 @@ describe('OcpClient', () => {
     const ocp = new OcpClient({ ledger, factory });
 
     expect(ocp.factory).toEqual(factory);
+  });
+
+  it('rejects incomplete client-level factory config', () => {
+    const ledger = createLedgerJsonApiClient(config);
+
+    expect(
+      () =>
+        new OcpClient({
+          ledger,
+          factory: { contractId: 'factory-cid' } as unknown as { contractId: string; templateId: string },
+        })
+    ).toThrow('factory override must include contractId and templateId');
+  });
+
+  it('rejects injected environment labels that do not match the ledger network', () => {
+    const ledger = createLedgerJsonApiClient({ network: 'devnet' });
+
+    expect(() => new OcpClient({ ledger, environment: 'mainnet' })).toThrow(
+      'environment mainnet does not match ledger network devnet'
+    );
+  });
+
+  it('creates a LocalNet client from environment defaults', () => {
+    const ocp = OcpClient.forLocalNet({ party: 'app_provider::party' });
+
+    expect(ocp.environment).toBe('localnet');
+    expect(ocp.isLocalNet()).toBe(true);
+    expect(ocp.isProduction()).toBe(false);
+    expect(mockedCanton.__instances).toHaveLength(1);
+    expect(mockedCanton.__instances[0]?.config).toMatchObject({
+      network: 'localnet',
+      provider: 'app-provider',
+      partyId: 'app_provider::party',
+      apis: {
+        LEDGER_JSON_API: {
+          apiUrl: 'http://localhost:3975',
+          auth: {
+            grantType: 'client_credentials',
+            clientId: 'ocp-sdk',
+          },
+        },
+        VALIDATOR_API: {
+          apiUrl: 'http://localhost:3903',
+        },
+      },
+    });
+  });
+
+  it('creates a DevNet client from explicit OAuth2 config', () => {
+    const ocp = OcpClient.forDevNet({
+      ledgerApiUrl: 'https://ledger.devnet.example.com',
+      validatorApiUrl: 'https://validator.devnet.example.com',
+      authUrl: 'https://auth.example.com/token',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      provider: '5n',
+      partyId: 'issuer::party',
+    });
+
+    expect(ocp.environment).toBe('devnet');
+    expect(mockedCanton.__instances).toHaveLength(1);
+    expect(mockedCanton.__instances[0]?.config).toMatchObject({
+      network: 'devnet',
+      provider: '5n',
+      authUrl: 'https://auth.example.com/token',
+      partyId: 'issuer::party',
+      apis: {
+        LEDGER_JSON_API: {
+          apiUrl: 'https://ledger.devnet.example.com',
+          auth: {
+            grantType: 'client_credentials',
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+          },
+        },
+        VALIDATOR_API: {
+          apiUrl: 'https://validator.devnet.example.com',
+        },
+      },
+    });
+  });
+
+  it('tracks production safety helper state', () => {
+    const ocp = OcpClient.forMainNet({
+      ledgerApiUrl: 'https://ledger.mainnet.example.com',
+      authUrl: 'https://auth.example.com/token',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      productionSafetyChecks: true,
+    });
+
+    expect(ocp.isProduction()).toBe(true);
+    expect(ocp.areProductionSafetyChecksEnabled()).toBe(true);
+    expect(ocp.setProductionSafetyChecks(false)).toBe(ocp);
+    expect(ocp.areProductionSafetyChecksEnabled()).toBe(false);
   });
 });
 
@@ -110,6 +209,41 @@ describe('OcpClient OpenCapTable.issuerAuthorization.authorize', () => {
       factoryContractId: 'per-call-cid-only',
     });
     expect(mockedAuthorizeIssuer).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires explicit factory coordinates for custom environment authorization', async () => {
+    const ledger = createLedgerJsonApiClient({ network: 'localnet' });
+    const ocp = new OcpClient({ ledger, environment: 'custom' });
+
+    await expect(ocp.OpenCapTable.issuerAuthorization.authorize({ issuer: 'issuer::party' })).rejects.toThrow(
+      'factory override is required for custom issuer authorization'
+    );
+    expect(mockedAuthorizeIssuer).not.toHaveBeenCalled();
+  });
+
+  it('requires explicit factory coordinates for LocalNet authorization', async () => {
+    const ledger = createLedgerJsonApiClient({ network: 'localnet' });
+    const ocp = new OcpClient({ ledger, environment: 'localnet' });
+
+    await expect(ocp.OpenCapTable.issuerAuthorization.authorize({ issuer: 'issuer::party' })).rejects.toThrow(
+      'factory override is required for localnet issuer authorization'
+    );
+    expect(mockedAuthorizeIssuer).not.toHaveBeenCalled();
+  });
+
+  it('does not treat a mutated partial client-level factory as explicit coordinates', async () => {
+    const ledger = createLedgerJsonApiClient({ network: 'localnet' });
+    const ocp = new OcpClient({
+      ledger,
+      environment: 'localnet',
+      factory: { contractId: 'client-factory-cid', templateId: 'client-factory-tid' },
+    });
+    (ocp.factory as unknown as { templateId?: string }).templateId = undefined;
+
+    await expect(ocp.OpenCapTable.issuerAuthorization.authorize({ issuer: 'issuer::party' })).rejects.toThrow(
+      'factory override must include contractId and templateId'
+    );
+    expect(mockedAuthorizeIssuer).not.toHaveBeenCalled();
   });
 });
 

--- a/test/config/environment.test.ts
+++ b/test/config/environment.test.ts
@@ -1,0 +1,246 @@
+import {
+  detectEnvironment,
+  loadEnvironmentConfigFromEnv,
+  LOCALNET_PRESET,
+  resolveEnvironmentConfig,
+  toCantonConfig,
+  validateConfig,
+} from '../../src/environment';
+
+describe('environment configuration', () => {
+  it('provides a LocalNet preset with cn-quickstart endpoints', () => {
+    expect(LOCALNET_PRESET).toMatchObject({
+      environment: 'localnet',
+      ledgerApiUrl: 'http://localhost:3975',
+      validatorApiUrl: 'http://localhost:3903',
+      authMode: 'shared-secret',
+    });
+  });
+
+  it('detects common environments from ledger API URLs', () => {
+    expect(detectEnvironment('http://localhost:3975')).toBe('localnet');
+    expect(detectEnvironment('https://ledger.devnet.example.com')).toBe('devnet');
+    expect(detectEnvironment('https://ledger.testnet.example.com')).toBe('testnet');
+    expect(detectEnvironment('https://ledger.mainnet.example.com')).toBe('mainnet');
+    expect(detectEnvironment('https://ledger.scratchnet.example.com')).toBe('scratchnet');
+    expect(detectEnvironment('https://ledger.internal.example.com')).toBe('custom');
+  });
+
+  it('does not detect environments from unrelated URL substrings', () => {
+    expect(detectEnvironment('https://ledger.contestnet.example.com')).toBe('custom');
+    expect(detectEnvironment('https://scratchpad.example.com/ledger')).toBe('custom');
+    expect(detectEnvironment('https://ledger.example.com/testnet/v1')).toBe('testnet');
+  });
+
+  it('validates oauth2 credentials and warns for production', () => {
+    const result = validateConfig({
+      environment: 'mainnet',
+      ledgerApiUrl: 'https://ledger.mainnet.example.com',
+      authMode: 'oauth2',
+      authUrl: 'https://auth.example.com/token',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toContain('mainnet configuration targets production Canton services.');
+  });
+
+  it('rejects incomplete oauth2 config', () => {
+    const result = validateConfig({
+      environment: 'devnet',
+      ledgerApiUrl: 'https://ledger.devnet.example.com',
+      authMode: 'oauth2',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual([
+      'authUrl is required for oauth2 auth mode.',
+      'clientId is required for oauth2 auth mode.',
+      'clientSecret is required for oauth2 auth mode.',
+    ]);
+  });
+
+  it('loads environment config from CANTON_* variables', () => {
+    const config = loadEnvironmentConfigFromEnv({
+      CANTON_LEDGER_API_URL: ' https://ledger.devnet.example.com ',
+      CANTON_VALIDATOR_API_URL: 'https://validator.devnet.example.com',
+      CANTON_SCAN_API_URL: 'https://scan.devnet.example.com',
+      CANTON_ENVIRONMENT: 'DevNet',
+      CANTON_AUTH_MODE: 'OAUTH2',
+      CANTON_AUTH_URL: 'https://auth.example.com/token',
+      CANTON_CLIENT_ID: 'client-id',
+      CANTON_CLIENT_SECRET: ' client-secret ',
+      CANTON_PROVIDER: '5n',
+      CANTON_PARTY_ID: 'issuer::party',
+      CANTON_MANAGED_PARTIES: 'issuer::party,holder::party',
+      CANTON_AUDIENCE: 'https://devnet.example.com',
+      CANTON_SCOPE: 'openid canton',
+      CANTON_DEBUG: 'true',
+    });
+
+    expect(config).toMatchObject({
+      environment: 'devnet',
+      ledgerApiUrl: 'https://ledger.devnet.example.com',
+      validatorApiUrl: 'https://validator.devnet.example.com',
+      scanApiUrl: 'https://scan.devnet.example.com',
+      authMode: 'oauth2',
+      authUrl: 'https://auth.example.com/token',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      provider: '5n',
+      partyId: 'issuer::party',
+      managedParties: ['issuer::party', 'holder::party'],
+      audience: 'https://devnet.example.com',
+      scope: 'openid canton',
+      debug: true,
+    });
+  });
+
+  it('keeps LocalNet preset defaults when env variables are omitted', () => {
+    const config = loadEnvironmentConfigFromEnv({});
+
+    expect(config).toMatchObject({
+      environment: 'localnet',
+      ledgerApiUrl: 'http://localhost:3975',
+      validatorApiUrl: 'http://localhost:3903',
+      scanApiUrl: 'http://localhost:4000/api/scan',
+      authMode: 'shared-secret',
+      sharedSecret: 'unsafe',
+    });
+  });
+
+  it('rejects invalid CANTON_AUTH_MODE values', () => {
+    expect(() =>
+      loadEnvironmentConfigFromEnv({
+        CANTON_LEDGER_API_URL: 'https://ledger.devnet.example.com',
+        CANTON_AUTH_MODE: 'password',
+      })
+    ).toThrow('authMode must be one of: shared-secret, oauth2');
+  });
+
+  it('rejects unknown CANTON_ENVIRONMENT values instead of treating them as custom', () => {
+    expect(() =>
+      loadEnvironmentConfigFromEnv({
+        CANTON_ENVIRONMENT: 'mainent',
+        CANTON_LEDGER_API_URL: 'https://ledger.mainnet.example.com',
+      })
+    ).toThrow('Unsupported Canton environment: mainent');
+  });
+
+  it('reports unsupported direct environment inputs without throwing from preset lookup', () => {
+    const result = validateConfig({
+      environment: 'mystery',
+      ledgerApiUrl: 'https://ledger.internal.example.com',
+      authMode: 'oauth2',
+      authUrl: 'https://auth.example.com/token',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('Unsupported Canton environment: mystery');
+  });
+
+  it('rejects explicit environment labels that conflict with recognized ledger URLs', () => {
+    const result = validateConfig({
+      environment: 'mainnet',
+      ledgerApiUrl: 'https://ledger.devnet.example.com',
+      authMode: 'oauth2',
+      authUrl: 'https://auth.example.com/token',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('ledgerApiUrl appears to target devnet, but environment is mainnet.');
+  });
+
+  it('rejects shared-secret auth outside LocalNet without an explicit secret', () => {
+    const result = validateConfig({
+      environment: 'devnet',
+      ledgerApiUrl: 'https://ledger.devnet.example.com',
+      authMode: 'shared-secret',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('sharedSecret is required for shared-secret auth mode outside localnet.');
+  });
+
+  it('trims direct config string fields when resolving', () => {
+    const config = resolveEnvironmentConfig({
+      environment: 'devnet',
+      ledgerApiUrl: ' https://ledger.devnet.example.com ',
+      validatorApiUrl: ' https://validator.devnet.example.com ',
+      scanApiUrl: ' https://scan.devnet.example.com ',
+      authMode: 'oauth2',
+      authUrl: ' https://auth.example.com/token ',
+      clientId: ' client-id ',
+      clientSecret: ' client-secret ',
+      provider: ' 5n ',
+      partyId: ' issuer::party ',
+      userId: ' sdk-user ',
+      managedParties: [' issuer::party ', ' ', 'holder::party'],
+      audience: ' https://devnet.example.com ',
+      scope: ' openid canton ',
+    });
+
+    expect(config).toMatchObject({
+      ledgerApiUrl: 'https://ledger.devnet.example.com',
+      validatorApiUrl: 'https://validator.devnet.example.com',
+      scanApiUrl: 'https://scan.devnet.example.com',
+      authUrl: 'https://auth.example.com/token',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      provider: '5n',
+      partyId: 'issuer::party',
+      userId: 'sdk-user',
+      managedParties: ['issuer::party', 'holder::party'],
+      audience: 'https://devnet.example.com',
+      scope: 'openid canton',
+    });
+  });
+
+  it('converts a resolved config to Canton SDK config', () => {
+    const cantonConfig = toCantonConfig({
+      environment: 'custom',
+      ledgerApiUrl: 'https://ledger.internal.example.com',
+      validatorApiUrl: 'https://validator.internal.example.com',
+      authMode: 'oauth2',
+      authUrl: 'https://auth.example.com/token',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      party: 'issuer::party',
+    });
+
+    expect(cantonConfig).toMatchObject({
+      network: 'localnet',
+      authUrl: 'https://auth.example.com/token',
+      partyId: 'issuer::party',
+      apis: {
+        LEDGER_JSON_API: {
+          apiUrl: 'https://ledger.internal.example.com',
+          auth: {
+            grantType: 'client_credentials',
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+          },
+          partyId: 'issuer::party',
+        },
+        VALIDATOR_API: {
+          apiUrl: 'https://validator.internal.example.com',
+        },
+      },
+    });
+  });
+
+  it('creates shared-secret token generators without external JWT dependencies', async () => {
+    const cantonConfig = toCantonConfig(resolveEnvironmentConfig({ environment: 'localnet' }));
+    const tokenGenerator = cantonConfig.apis?.LEDGER_JSON_API?.auth.tokenGenerator;
+
+    expect(tokenGenerator).toBeDefined();
+    const token = await tokenGenerator?.();
+    expect(token?.split('.')).toHaveLength(3);
+  });
+});

--- a/test/mocks/fairmint-canton-node-sdk.ts
+++ b/test/mocks/fairmint-canton-node-sdk.ts
@@ -142,6 +142,38 @@ export class ValidatorApiClient extends BaseClient {
   }
 }
 
+export class Canton {
+  public static __instances: Canton[] = [];
+  public readonly ledger: LedgerJsonApiClient;
+  public readonly validator: ValidatorApiClient;
+  public readonly scan: unknown;
+  private partyId?: string;
+
+  constructor(public readonly config: ClientConfig) {
+    this.ledger = new LedgerJsonApiClient(config);
+    this.validator = new ValidatorApiClient(config);
+    this.scan = {};
+    this.partyId = config.partyId;
+    Canton.__instances.push(this);
+  }
+
+  public getNetwork(): string {
+    return this.config.network;
+  }
+
+  public getProvider(): string | undefined {
+    return this.config.provider;
+  }
+
+  public getPartyId(): string {
+    return this.partyId ?? this.validator.getPartyId();
+  }
+
+  public setPartyId(partyId: string): void {
+    this.partyId = partyId;
+  }
+}
+
 // Export the getFeaturedAppRightContractDetails function
 export async function getFeaturedAppRightContractDetails(validatorApi: ValidatorApiClient): Promise<any> {
   const featuredAppRight = await validatorApi.lookupFeaturedAppRight();


### PR DESCRIPTION
## Summary

Implements ENG-457 environment configuration support for `@open-captable-protocol/canton`:

- Adds typed OCP environment config, presets, validation, URL-based environment detection, `CANTON_*` env loading, and conversion into Canton SDK config.
- Adds `OcpClient` factory helpers: `create`, `forLocalNet`, `forDevNet`, `forTestNet`, `forMainNet`, and `fromEnv`.
- Adds runtime helpers for environment checks and production-safety flag state.
- Documents environment setup and env vars in the README.
- Covers config and factory behavior with focused unit tests.

## Validation

- `npm run format`
- `npm run lint`
- `npm test` (52 suites / 1653 tests)
- `npm run build`

Note: local validation in the isolated worktree required initializing `libs/Open-Cap-Format-OCF` and temporarily symlinking sibling `node_modules`; neither is part of the source diff.

Linear: https://linear.app/fairmint/issue/ENG-457/ocp-canton-sdk-environment-configuration-patterns

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mainnet OAuth2 config, shared-secret auth rules, and issuer authorization factory requirements on non-bundled networks—misconfiguration could block auth flows or point clients at the wrong Canton environment.
> 
> **Overview**
> Adds a new **`environment`** module with typed presets (localnet through mainnet/custom), validation, URL-based environment detection, **`CANTON_*`** env loading, and mapping into **`Canton`** SDK config—including shared-secret JWT generation for localnet.
> 
> **`OcpClient`** gains static factories (`create`, `forLocalNet`, `forDevNet`, `forTestNet`, `forMainNet`, `fromEnv`) that build ledger/validator via **`Canton`**, plus optional **`environment`** tracking, **`isLocalNet`/`isProduction`**, and a **production safety checks** flag (stored only for now). The constructor still accepts injected clients but now validates factory coordinates and that an explicit **`environment`** matches **`ledger.getNetwork()`**.
> 
> **Issuer authorization** is stricter: incomplete client-level factory configs fail fast, and **localnet**, **scratchnet**, and **custom** require explicit factory **`contractId`/`templateId`** (or per-call overrides) instead of relying on bundled network defaults.
> 
> The package re-exports **`environment`** from **`index.ts`**; tests cover config resolution and the new client/factory behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b301fba506cea9712af76a25f6823f48cea5f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an environment configuration module with network presets, environment inference from ledger URLs, and env-based configuration loading/normalization.
  * Enhanced `OcpClient` with environment-aware constructors/factories (`create`, `forLocalNet`, `forDevNet`, `forTestNet`, `forMainNet`, `fromEnv`) plus production safety-check enablement controls.
  * Re-exported the environment module from the package entrypoint.
  * Expanded README with an “Environment Configuration” guide and supported `CANTON_*` variables.
* **Bug Fixes**
  * Issuer authorization now enforces required factory coordinates for specific environments when not explicitly provided.
* **Tests**
  * Added/updated Jest suites validating environment config resolution/validation, preset wiring, and the authorization/factory enforcement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->