### PR TITLE
[codex] Fix skipped integration tests

### DIFF
--- a/test/fixtures/production/stockClassSplit.json
+++ b/test/fixtures/production/stockClassSplit.json
@@ -7,8 +7,6 @@
     "numerator": "10",
     "denominator": "1"
   },
-  "board_approval_date": "2024-06-01",
-  "stockholder_approval_date": "2024-06-10",
   "comments": [
     "10:1 forward stock split of Common Stock",
     "All outstanding shares, options, and convertibles multiplied by 10",

--- a/test/fixtures/synthetic/equityCompensationRelease.json
+++ b/test/fixtures/synthetic/equityCompensationRelease.json
@@ -3,6 +3,7 @@
   "id": "test-equity-comp-release-001",
   "object_type": "TX_EQUITY_COMPENSATION_RELEASE",
   "date": "2025-04-01",
+  "settlement_date": "2025-04-03",
   "security_id": "test-security-rsu-release-001",
   "quantity": "2500",
   "resulting_security_ids": ["test-security-released-shares-001"],

--- a/test/fixtures/synthetic/equityCompensationRepricing.json
+++ b/test/fixtures/synthetic/equityCompensationRepricing.json
@@ -4,7 +4,10 @@
   "object_type": "TX_EQUITY_COMPENSATION_REPRICING",
   "date": "2025-01-15",
   "security_id": "test-security-option-reprice-001",
-  "resulting_security_ids": ["test-security-option-repriced-001"],
+  "new_exercise_price": {
+    "amount": "10.00",
+    "currency": "USD"
+  },
   "comments": [
     "Underwater option repricing approved by Board and Compensation Committee",
     "Original exercise price: $25.00",

--- a/test/fixtures/synthetic/stockClassConversionRatioAdjustment.json
+++ b/test/fixtures/synthetic/stockClassConversionRatioAdjustment.json
@@ -6,13 +6,16 @@
   "stock_class_id": "test-stock-class-preferred-001",
   "new_ratio_conversion_mechanism": {
     "type": "RATIO_CONVERSION",
+    "conversion_price": {
+      "amount": "0",
+      "currency": "USD"
+    },
     "ratio": {
       "numerator": "11",
       "denominator": "10"
     },
     "rounding_type": "FLOOR"
   },
-  "board_approval_date": "2025-06-01",
   "comments": [
     "Conversion ratio adjusted following 10:1 stock split of common stock",
     "Original conversion ratio: 1:1",

--- a/test/fixtures/synthetic/stockConversion.json
+++ b/test/fixtures/synthetic/stockConversion.json
@@ -4,9 +4,7 @@
   "object_type": "TX_STOCK_CONVERSION",
   "date": "2025-06-01",
   "security_id": "test-security-preferred-convert-001",
-  "quantity": "500000",
+  "quantity_converted": "500000",
   "resulting_security_ids": ["test-security-common-converted-001"],
-  "reason_text": "Automatic conversion of Series Seed Preferred to Common upon IPO",
-  "stock_class_id": "test-stock-class-common-001",
   "comments": ["Conversion ratio: 1:1 per Certificate of Incorporation"]
 }

--- a/test/fixtures/synthetic/stockPlanReturnToPool.json
+++ b/test/fixtures/synthetic/stockPlanReturnToPool.json
@@ -3,6 +3,7 @@
   "id": "test-stock-plan-return-001",
   "object_type": "TX_STOCK_PLAN_RETURN_TO_POOL",
   "date": "2025-04-20",
+  "security_id": "test-security-plan-return-001",
   "stock_plan_id": "test-stock-plan-001",
   "quantity": "25000",
   "reason_text": "Forfeited unvested shares returned to plan pool upon employee termination",

--- a/test/fixtures/synthetic/warrantExercise.json
+++ b/test/fixtures/synthetic/warrantExercise.json
@@ -4,7 +4,7 @@
   "object_type": "TX_WARRANT_EXERCISE",
   "date": "2025-05-15",
   "security_id": "test-security-warrant-exercise-001",
-  "quantity": "75000",
+  "trigger_id": "test-warrant-trigger-001",
   "resulting_security_ids": ["test-security-warrant-shares-001"],
   "consideration_text": "Cashless exercise at fair market value of $20.00 per share",
   "comments": [

--- a/test/integration/entities/exerciseConversionTypes.integration.test.ts
+++ b/test/integration/entities/exerciseConversionTypes.integration.test.ts
@@ -18,16 +18,17 @@
  * ```
  */
 
-import { createIntegrationTestSuite } from '../setup';
+import { createIntegrationTestSuite, type IntegrationTestContext } from '../setup';
 import {
   createTestConvertibleConversionData,
-  createTestStakeholderData,
   createTestStockConversionData,
-  createTestStockIssuanceData,
   createTestWarrantExerciseData,
   generateTestId,
   requireCreatedEventBlob,
+  setupConvertibleSecurity,
+  setupStockSecurity,
   setupTestIssuer,
+  setupWarrantSecurity,
 } from '../utils';
 
 /**
@@ -41,6 +42,19 @@ function extractContractIdString(cid: { value: unknown }): string {
   return cid.value as string;
 }
 
+async function getCapTableDetails(ctx: IntegrationTestContext, contractId: string, synchronizerId: string) {
+  const events = await ctx.ocp.ledger.getEventsByContractId({ contractId });
+  if (!events.created?.createdEvent) {
+    throw new Error('Failed to get CapTable created event');
+  }
+  return {
+    templateId: events.created.createdEvent.templateId,
+    contractId,
+    createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
+    synchronizerId,
+  };
+}
+
 createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
   /**
    * Test: Create warrant exercise transaction via batch API.
@@ -49,7 +63,7 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
    * that the security_id references an existing warrant. Without setting up a full
    * warrant issuance lifecycle first, this will fail with COMMAND_PREPROCESSING_FAILED.
    */
-  test.skip('creates warrant exercise and reads back as OCF (requires warrant issuance)', async () => {
+  test('creates warrant exercise and reads back as OCF (requires warrant issuance)', async () => {
     const ctx = getContext();
 
     const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -58,48 +72,27 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
       issuerParty: ctx.issuerParty,
     });
 
-    // Create stakeholder first
-    const stakeholderData = createTestStakeholderData({
-      id: generateTestId('warrant-holder'),
-    });
-
-    const stakeholderBatch = ctx.ocp.OpenCapTable.capTable.update({
-      capTableContractId: issuerSetup.issuerContractId,
+    const warrantSecurity = await setupWarrantSecurity(ctx.ocp, {
+      issuerContractId: issuerSetup.issuerContractId,
+      issuerParty: ctx.issuerParty,
       capTableContractDetails: issuerSetup.capTableContractDetails,
-      actAs: [ctx.issuerParty],
     });
+    const capTableDetails = await getCapTableDetails(
+      ctx,
+      warrantSecurity.capTableContractId,
+      issuerSetup.capTableContractDetails.synchronizerId
+    );
 
-    const stakeholderResult = await stakeholderBatch.create('stakeholder', stakeholderData).execute();
-    const newCapTableCid = stakeholderResult.updatedCapTableCid;
-
-    // Get updated cap table details
-    const capTableEvents = await ctx.ocp.ledger.getEventsByContractId({ contractId: newCapTableCid });
-    if (!capTableEvents.created?.createdEvent) {
-      throw new Error('Failed to get CapTable created event');
-    }
-    const newCapTableDetails = {
-      templateId: capTableEvents.created.createdEvent.templateId,
-      contractId: newCapTableCid,
-      createdEventBlob: requireCreatedEventBlob(capTableEvents.created.createdEvent),
-      synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
-    };
-
-    // TODO: First need to issue a warrant with:
-    // - warrantIssuance (requires stakeholder_id, stock_class_id or stock_plan_id)
-    // Then exercise it with warrantExercise
-
-    const warrantSecurityId = generateTestId('warrant-security');
     const resultingStockSecurityId = generateTestId('resulting-stock');
 
     const warrantExerciseData = createTestWarrantExerciseData({
-      security_id: warrantSecurityId,
+      security_id: warrantSecurity.securityId,
       resulting_security_ids: [resultingStockSecurityId],
-      quantity: '1000',
     });
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
-      capTableContractId: newCapTableCid,
-      capTableContractDetails: newCapTableDetails,
+      capTableContractId: warrantSecurity.capTableContractId,
+      capTableContractDetails: capTableDetails,
       actAs: [ctx.issuerParty],
     });
 
@@ -112,8 +105,7 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
     });
 
     expect(ocfResult.data.object_type).toBe('TX_WARRANT_EXERCISE');
-    expect(ocfResult.data.security_id).toBe(warrantSecurityId);
-    expect(ocfResult.data.quantity).toBe('1000');
+    expect(ocfResult.data.security_id).toBe(warrantSecurity.securityId);
     expect(ocfResult.data.resulting_security_ids).toContain(resultingStockSecurityId);
   });
 
@@ -124,7 +116,7 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
    * that the security_id references an existing convertible. Without setting up a full
    * convertible issuance lifecycle first, this will fail with COMMAND_PREPROCESSING_FAILED.
    */
-  test.skip('creates convertible conversion and reads back as OCF (requires convertible issuance)', async () => {
+  test('creates convertible conversion and reads back as OCF (requires convertible issuance)', async () => {
     const ctx = getContext();
 
     const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -133,21 +125,27 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
       issuerParty: ctx.issuerParty,
     });
 
-    // TODO: First need to issue a convertible with:
-    // - convertibleIssuance (requires stakeholder_id, investment_amount, etc.)
-    // Then convert it with convertibleConversion
+    const convertibleSecurity = await setupConvertibleSecurity(ctx.ocp, {
+      issuerContractId: issuerSetup.issuerContractId,
+      issuerParty: ctx.issuerParty,
+      capTableContractDetails: issuerSetup.capTableContractDetails,
+    });
+    const capTableDetails = await getCapTableDetails(
+      ctx,
+      convertibleSecurity.capTableContractId,
+      issuerSetup.capTableContractDetails.synchronizerId
+    );
 
-    const convertibleSecurityId = generateTestId('convertible-security');
     const resultingStockSecurityId = generateTestId('resulting-stock');
 
     const convertibleConversionData = createTestConvertibleConversionData({
-      security_id: convertibleSecurityId,
+      security_id: convertibleSecurity.securityId,
       resulting_security_ids: [resultingStockSecurityId],
     });
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
-      capTableContractId: issuerSetup.issuerContractId,
-      capTableContractDetails: issuerSetup.capTableContractDetails,
+      capTableContractId: convertibleSecurity.capTableContractId,
+      capTableContractDetails: capTableDetails,
       actAs: [ctx.issuerParty],
     });
 
@@ -160,7 +158,7 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
     });
 
     expect(ocfResult.data.object_type).toBe('TX_CONVERTIBLE_CONVERSION');
-    expect(ocfResult.data.security_id).toBe(convertibleSecurityId);
+    expect(ocfResult.data.security_id).toBe(convertibleSecurity.securityId);
     expect(ocfResult.data.resulting_security_ids).toContain(resultingStockSecurityId);
   });
 
@@ -171,7 +169,7 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
    * that the security_id references an existing stock. Without setting up a full
    * stock issuance lifecycle first, this will fail with COMMAND_PREPROCESSING_FAILED.
    */
-  test.skip('creates stock conversion and reads back as OCF (requires stock issuance)', async () => {
+  test('creates stock conversion and reads back as OCF (requires stock issuance)', async () => {
     const ctx = getContext();
 
     const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -180,24 +178,28 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
       issuerParty: ctx.issuerParty,
     });
 
-    // TODO: First need to issue stock with:
-    // - stockClass (has numeric encoding issues)
-    // - stakeholder
-    // - stockIssuance
-    // Then convert it with stockConversion
+    const stockSecurity = await setupStockSecurity(ctx.ocp, {
+      issuerContractId: issuerSetup.issuerContractId,
+      issuerParty: ctx.issuerParty,
+      capTableContractDetails: issuerSetup.capTableContractDetails,
+    });
+    const capTableDetails = await getCapTableDetails(
+      ctx,
+      stockSecurity.capTableContractId,
+      issuerSetup.capTableContractDetails.synchronizerId
+    );
 
-    const stockSecurityId = generateTestId('stock-security');
     const resultingSecurityId = generateTestId('resulting-preferred');
 
     const stockConversionData = createTestStockConversionData({
-      security_id: stockSecurityId,
+      security_id: stockSecurity.securityId,
       resulting_security_ids: [resultingSecurityId],
-      quantity: '5000',
+      quantity_converted: '5000',
     });
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
-      capTableContractId: issuerSetup.issuerContractId,
-      capTableContractDetails: issuerSetup.capTableContractDetails,
+      capTableContractId: stockSecurity.capTableContractId,
+      capTableContractDetails: capTableDetails,
       actAs: [ctx.issuerParty],
     });
 
@@ -210,8 +212,8 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
     });
 
     expect(ocfResult.data.object_type).toBe('TX_STOCK_CONVERSION');
-    expect(ocfResult.data.security_id).toBe(stockSecurityId);
-    expect(ocfResult.data.quantity).toBe('5000');
+    expect(ocfResult.data.security_id).toBe(stockSecurity.securityId);
+    expect(ocfResult.data.quantity_converted).toBe('5000');
     expect(ocfResult.data.resulting_security_ids).toContain(resultingSecurityId);
   });
 
@@ -340,7 +342,7 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
    *
    * Note: This requires a stock class, which has numeric encoding issues.
    */
-  test.skip('creates stock issuance prerequisite for conversion', async () => {
+  test('creates stock issuance prerequisite for conversion', async () => {
     const ctx = getContext();
 
     const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -349,48 +351,13 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
       issuerParty: ctx.issuerParty,
     });
 
-    // Create stakeholder
-    const stakeholderData = createTestStakeholderData({
-      id: generateTestId('stock-holder'),
-    });
-
-    const stakeholderBatch = ctx.ocp.OpenCapTable.capTable.update({
-      capTableContractId: issuerSetup.issuerContractId,
+    const stockSecurity = await setupStockSecurity(ctx.ocp, {
+      issuerContractId: issuerSetup.issuerContractId,
+      issuerParty: ctx.issuerParty,
       capTableContractDetails: issuerSetup.capTableContractDetails,
-      actAs: [ctx.issuerParty],
     });
 
-    const stakeholderResult = await stakeholderBatch.create('stakeholder', stakeholderData).execute();
-    const newCapTableCid = stakeholderResult.updatedCapTableCid;
-
-    // Get updated cap table details
-    const capTableEvents = await ctx.ocp.ledger.getEventsByContractId({ contractId: newCapTableCid });
-    if (!capTableEvents.created?.createdEvent) {
-      throw new Error('Failed to get CapTable created event');
-    }
-    const newCapTableDetails = {
-      templateId: capTableEvents.created.createdEvent.templateId,
-      contractId: newCapTableCid,
-      createdEventBlob: requireCreatedEventBlob(capTableEvents.created.createdEvent),
-      synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
-    };
-
-    // Create stock issuance
-    const stockClassId = generateTestId('stock-class');
-    const stockIssuanceData = createTestStockIssuanceData({
-      stakeholder_id: stakeholderData.id,
-      stock_class_id: stockClassId,
-      quantity: '10000',
-    });
-
-    const issuanceBatch = ctx.ocp.OpenCapTable.capTable.update({
-      capTableContractId: newCapTableCid,
-      capTableContractDetails: newCapTableDetails,
-      actAs: [ctx.issuerParty],
-    });
-
-    // Note: This will likely fail due to missing stock class
-    const result = await issuanceBatch.create('stockIssuance', stockIssuanceData).execute();
-    expect(result.createdCids).toHaveLength(1);
+    expect(stockSecurity.stockIssuanceContractId).toBeTruthy();
+    expect(stockSecurity.securityId).toBeTruthy();
   });
 });

--- a/test/integration/entities/exerciseConversionTypes.integration.test.ts
+++ b/test/integration/entities/exerciseConversionTypes.integration.test.ts
@@ -18,13 +18,13 @@
  * ```
  */
 
-import { createIntegrationTestSuite, type IntegrationTestContext } from '../setup';
+import { createIntegrationTestSuite } from '../setup';
 import {
   createTestConvertibleConversionData,
   createTestStockConversionData,
   createTestWarrantExerciseData,
   generateTestId,
-  requireCreatedEventBlob,
+  getCapTableDetails,
   setupConvertibleSecurity,
   setupStockSecurity,
   setupTestIssuer,
@@ -40,19 +40,6 @@ function extractContractIdString(cid: { value: unknown }): string {
   // OcfContractId is a tagged union like { tag: "CidStakeholder", value: ContractId<Stakeholder> }
   // ContractId<T> is just a string in the JSON representation
   return cid.value as string;
-}
-
-async function getCapTableDetails(ctx: IntegrationTestContext, contractId: string, synchronizerId: string) {
-  const events = await ctx.ocp.ledger.getEventsByContractId({ contractId });
-  if (!events.created?.createdEvent) {
-    throw new Error('Failed to get CapTable created event');
-  }
-  return {
-    templateId: events.created.createdEvent.templateId,
-    contractId,
-    createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
-    synchronizerId,
-  };
 }
 
 createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
@@ -78,7 +65,7 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
       capTableContractDetails: issuerSetup.capTableContractDetails,
     });
     const capTableDetails = await getCapTableDetails(
-      ctx,
+      ctx.ocp,
       warrantSecurity.capTableContractId,
       issuerSetup.capTableContractDetails.synchronizerId
     );
@@ -131,7 +118,7 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
       capTableContractDetails: issuerSetup.capTableContractDetails,
     });
     const capTableDetails = await getCapTableDetails(
-      ctx,
+      ctx.ocp,
       convertibleSecurity.capTableContractId,
       issuerSetup.capTableContractDetails.synchronizerId
     );
@@ -184,7 +171,7 @@ createIntegrationTestSuite('Exercise and Conversion Types', (getContext) => {
       capTableContractDetails: issuerSetup.capTableContractDetails,
     });
     const capTableDetails = await getCapTableDetails(
-      ctx,
+      ctx.ocp,
       stockSecurity.capTableContractId,
       issuerSetup.capTableContractDetails.synchronizerId
     );

--- a/test/integration/entities/stockClassAdjustments.integration.test.ts
+++ b/test/integration/entities/stockClassAdjustments.integration.test.ts
@@ -19,27 +19,15 @@
  * ```
  */
 
-import { createIntegrationTestSuite, type IntegrationTestContext } from '../setup';
+import { createIntegrationTestSuite } from '../setup';
 import {
   generateDateString,
   generateTestId,
+  getCapTableDetails,
   requireCreatedEventBlob,
   setupStockSecurity,
   setupTestIssuer,
 } from '../utils';
-
-async function getCapTableDetails(ctx: IntegrationTestContext, contractId: string, synchronizerId: string) {
-  const events = await ctx.ocp.ledger.getEventsByContractId({ contractId });
-  if (!events.created?.createdEvent) {
-    throw new Error('Failed to get CapTable created event');
-  }
-  return {
-    templateId: events.created.createdEvent.templateId,
-    contractId,
-    createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
-    synchronizerId,
-  };
-}
 
 createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
   /**
@@ -67,7 +55,7 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
       capTableContractDetails: issuerSetup.capTableContractDetails,
     });
     const capTableContractDetails = await getCapTableDetails(
-      ctx,
+      ctx.ocp,
       stockSecurity.capTableContractId,
       issuerSetup.capTableContractDetails.synchronizerId
     );
@@ -119,7 +107,7 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
       capTableContractDetails: issuerSetup.capTableContractDetails,
     });
     const capTableContractDetails = await getCapTableDetails(
-      ctx,
+      ctx.ocp,
       stockSecurity.capTableContractId,
       issuerSetup.capTableContractDetails.synchronizerId
     );

--- a/test/integration/entities/stockClassAdjustments.integration.test.ts
+++ b/test/integration/entities/stockClassAdjustments.integration.test.ts
@@ -382,9 +382,8 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
   /**
    * Test: Create stock class split with approval dates.
    *
-   * Note: The DAML StockClassSplitOcfData type does NOT have board_approval_date or
-   * stockholder_approval_date fields (unlike StockClassAuthorizedSharesAdjustmentOcfData).
-   * The native OCF type has these fields but they are not supported by the DAML contract.
+   * Note: board_approval_date and stockholder_approval_date are internal SDK extensions,
+   * not OCF StockClassSplit schema fields, and the DAML contract does not support them.
    *
    * Previously skipped: StockClassSplit uses OcfRatio which has nested Numeric fields.
    * The DAML JSON API v2 has encoding issues with nested Numeric fields.

--- a/test/integration/entities/stockClassAdjustments.integration.test.ts
+++ b/test/integration/entities/stockClassAdjustments.integration.test.ts
@@ -19,7 +19,7 @@
  * ```
  */
 
-import { createIntegrationTestSuite } from '../setup';
+import { createIntegrationTestSuite, type IntegrationTestContext } from '../setup';
 import {
   generateDateString,
   generateTestId,
@@ -28,16 +28,29 @@ import {
   setupTestIssuer,
 } from '../utils';
 
+async function getCapTableDetails(ctx: IntegrationTestContext, contractId: string, synchronizerId: string) {
+  const events = await ctx.ocp.ledger.getEventsByContractId({ contractId });
+  if (!events.created?.createdEvent) {
+    throw new Error('Failed to get CapTable created event');
+  }
+  return {
+    templateId: events.created.createdEvent.templateId,
+    contractId,
+    createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
+    synchronizerId,
+  };
+}
+
 createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
   /**
    * Test: Create a stock class split via batch API.
    *
    * Stock splits multiply existing shares by a ratio (e.g., 2-for-1 split).
    *
-   * SKIPPED: StockClassSplit uses OcfRatio which has nested Numeric fields.
+   * Previously skipped: StockClassSplit uses OcfRatio which has nested Numeric fields.
    * The DAML JSON API v2 has encoding issues with nested Numeric fields.
    */
-  test.skip('creates stock class split', async () => {
+  test('creates stock class split', async () => {
     const ctx = getContext();
 
     // Create issuer
@@ -47,13 +60,23 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
       issuerParty: ctx.issuerParty,
     });
 
-    // Create stock class split event
+    // Create a real stock class first; DAML validates stock_class_id references.
+    const stockSecurity = await setupStockSecurity(ctx.ocp, {
+      issuerContractId: issuerSetup.issuerContractId,
+      issuerParty: ctx.issuerParty,
+      capTableContractDetails: issuerSetup.capTableContractDetails,
+    });
+    const capTableContractDetails = await getCapTableDetails(
+      ctx,
+      stockSecurity.capTableContractId,
+      issuerSetup.capTableContractDetails.synchronizerId
+    );
+
     const splitId = generateTestId('stock-class-split');
-    const stockClassId = generateTestId('stock-class');
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
-      capTableContractId: issuerSetup.issuerContractId,
-      capTableContractDetails: issuerSetup.capTableContractDetails,
+      capTableContractId: stockSecurity.capTableContractId,
+      capTableContractDetails,
       actAs: [ctx.issuerParty],
     });
 
@@ -61,7 +84,7 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
       .create('stockClassSplit', {
         id: splitId,
         date: generateDateString(0),
-        stock_class_id: stockClassId,
+        stock_class_id: stockSecurity.stockClassId,
         split_ratio: { numerator: '2', denominator: '1' },
         comments: ['2-for-1 stock split'],
       })
@@ -76,10 +99,10 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
    *
    * Adjusts the conversion ratio for convertible instruments targeting a stock class.
    *
-   * SKIPPED: StockClassConversionRatioAdjustment uses OcfRatioConversionMechanism which has
+   * Previously skipped: StockClassConversionRatioAdjustment uses OcfRatioConversionMechanism which has
    * nested Numeric fields. The DAML JSON API v2 has encoding issues with nested Numeric fields.
    */
-  test.skip('creates stock class conversion ratio adjustment', async () => {
+  test('creates stock class conversion ratio adjustment', async () => {
     const ctx = getContext();
 
     // Create issuer
@@ -89,13 +112,23 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
       issuerParty: ctx.issuerParty,
     });
 
-    // Create conversion ratio adjustment event
+    // Create a real stock class first; DAML validates stock_class_id references.
+    const stockSecurity = await setupStockSecurity(ctx.ocp, {
+      issuerContractId: issuerSetup.issuerContractId,
+      issuerParty: ctx.issuerParty,
+      capTableContractDetails: issuerSetup.capTableContractDetails,
+    });
+    const capTableContractDetails = await getCapTableDetails(
+      ctx,
+      stockSecurity.capTableContractId,
+      issuerSetup.capTableContractDetails.synchronizerId
+    );
+
     const adjustmentId = generateTestId('conversion-ratio-adj');
-    const stockClassId = generateTestId('stock-class');
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
-      capTableContractId: issuerSetup.issuerContractId,
-      capTableContractDetails: issuerSetup.capTableContractDetails,
+      capTableContractId: stockSecurity.capTableContractId,
+      capTableContractDetails,
       actAs: [ctx.issuerParty],
     });
 
@@ -103,7 +136,7 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
       .create('stockClassConversionRatioAdjustment', {
         id: adjustmentId,
         date: generateDateString(0),
-        stock_class_id: stockClassId,
+        stock_class_id: stockSecurity.stockClassId,
         new_ratio_conversion_mechanism: {
           type: 'RATIO_CONVERSION',
           conversion_price: { amount: '0', currency: 'USD' },
@@ -365,10 +398,10 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
    * stockholder_approval_date fields (unlike StockClassAuthorizedSharesAdjustmentOcfData).
    * The native OCF type has these fields but they are not supported by the DAML contract.
    *
-   * SKIPPED: StockClassSplit uses OcfRatio which has nested Numeric fields.
+   * Previously skipped: StockClassSplit uses OcfRatio which has nested Numeric fields.
    * The DAML JSON API v2 has encoding issues with nested Numeric fields.
    */
-  test.skip('creates stock class split with approval dates', async () => {
+  test('rejects stock class split approval dates not supported by the OCF schema', async () => {
     const ctx = getContext();
 
     // Create issuer
@@ -384,8 +417,8 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
       actAs: [ctx.issuerParty],
     });
 
-    const result = await batch
-      .create('stockClassSplit', {
+    expect(() =>
+      batch.create('stockClassSplit', {
         id: generateTestId('split-with-dates'),
         date: generateDateString(0),
         stock_class_id: generateTestId('class-with-dates'),
@@ -394,9 +427,6 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
         stockholder_approval_date: generateDateString(-2),
         comments: ['Split with full approval chain'],
       })
-      .execute();
-
-    expect(result.createdCids).toHaveLength(1);
-    expect(result.updatedCapTableCid).toBeTruthy();
+    ).toThrow('board_approval_date');
   });
 });

--- a/test/integration/entities/valuationVesting.integration.test.ts
+++ b/test/integration/entities/valuationVesting.integration.test.ts
@@ -7,10 +7,8 @@
  * - VestingEvent (milestone-based vesting events)
  * - VestingAcceleration (accelerated vesting due to M&A, etc.)
  *
- * Note: Valuation tests are skipped because they require a valid stock_class_id that exists
- * in the DAML contract. Stock class creation via batch API has numeric encoding issues
- * (see capTableBatch.integration.test.ts comments), so we cannot easily create the
- * prerequisite stock class.
+ * Valuation tests create a real stock class prerequisite before submitting valuation payloads,
+ * because DAML validates stock_class_id references.
  *
  * Run with:
  *
@@ -19,8 +17,9 @@
  * ```
  */
 
-import { createIntegrationTestSuite } from '../setup';
+import { createIntegrationTestSuite, type IntegrationTestContext } from '../setup';
 import {
+  createTestValuationData,
   createTestVestingAccelerationData,
   createTestVestingEventData,
   createTestVestingStartData,
@@ -37,27 +36,129 @@ function extractContractIdString(cid: { value: unknown }): string {
   return cid.value;
 }
 
+async function getUpdatedCapTableDetails(ctx: IntegrationTestContext, contractId: string, synchronizerId: string) {
+  const events = await ctx.ocp.ledger.getEventsByContractId({ contractId });
+  if (!events.created?.createdEvent) {
+    throw new Error('Failed to get CapTable created event');
+  }
+
+  return {
+    templateId: events.created.createdEvent.templateId,
+    contractId,
+    createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
+    synchronizerId,
+  };
+}
+
 createIntegrationTestSuite('Valuation and Vesting types via batch API', (getContext) => {
   /**
    * Test: Create a valuation (409A) via batch API.
    *
-   * Previously skipped: Valuations require a valid stock_class_id that exists in the DAML contract.
-   * Stock class creation via batch API has numeric encoding issues, so we cannot easily
-   * create the prerequisite stock class needed for this test.
+   * Valuations require a valid stock_class_id that exists in the DAML contract.
    */
   test('creates valuation entity via batch API', async () => {
-    // This test requires a valid stock_class_id. Stock class creation via batch API
-    // has numeric encoding issues (JSON API expects Numeric as objects but receives strings).
-    // See capTableBatch.integration.test.ts for details on this limitation.
+    const ctx = getContext();
+
+    const issuerSetup = await setupTestIssuer(ctx.ocp, {
+      systemOperatorParty: ctx.systemOperatorParty,
+      ocpFactoryContractId: ctx.ocpFactoryContractId,
+      issuerParty: ctx.issuerParty,
+    });
+
+    const stockSecurity = await setupStockSecurity(ctx.ocp, {
+      issuerContractId: issuerSetup.issuerContractId,
+      issuerParty: ctx.issuerParty,
+      capTableContractDetails: issuerSetup.capTableContractDetails,
+    });
+    const capTableContractDetails = await getUpdatedCapTableDetails(
+      ctx,
+      stockSecurity.capTableContractId,
+      issuerSetup.capTableContractDetails.synchronizerId
+    );
+
+    const valuationData = createTestValuationData({
+      id: generateTestId('valuation'),
+      stock_class_id: stockSecurity.stockClassId,
+      price_per_share: { amount: '2.50', currency: 'USD' },
+    });
+
+    const batch = ctx.ocp.OpenCapTable.capTable.update({
+      capTableContractId: stockSecurity.capTableContractId,
+      capTableContractDetails,
+      actAs: [ctx.issuerParty],
+    });
+
+    const result = await batch.create('valuation', valuationData).execute();
+
+    expect(result.createdCids).toHaveLength(1);
+    expect(result.updatedCapTableCid).toBeTruthy();
+
+    const ocfResult = await ctx.ocp.OpenCapTable.valuation.get({
+      contractId: extractContractIdString(result.createdCids[0]),
+    });
+    expect(ocfResult.data.object_type).toBe('VALUATION');
+    expect(ocfResult.data.stock_class_id).toBe(valuationData.stock_class_id);
+    expect(Number(ocfResult.data.price_per_share.amount)).toBe(Number(valuationData.price_per_share.amount));
+    expect(ocfResult.data.price_per_share.currency).toBe(valuationData.price_per_share.currency);
   });
 
   /**
    * Test: Create multiple valuations in a single batch.
    *
-   * Previously skipped: See above - valuations require valid stock class references.
+   * Valuations require valid stock class references.
    */
   test('creates multiple valuations in batch', async () => {
-    // This test requires valid stock_class_ids for each valuation.
+    const ctx = getContext();
+
+    const issuerSetup = await setupTestIssuer(ctx.ocp, {
+      systemOperatorParty: ctx.systemOperatorParty,
+      ocpFactoryContractId: ctx.ocpFactoryContractId,
+      issuerParty: ctx.issuerParty,
+    });
+
+    const stockSecurity = await setupStockSecurity(ctx.ocp, {
+      issuerContractId: issuerSetup.issuerContractId,
+      issuerParty: ctx.issuerParty,
+      capTableContractDetails: issuerSetup.capTableContractDetails,
+    });
+    const capTableContractDetails = await getUpdatedCapTableDetails(
+      ctx,
+      stockSecurity.capTableContractId,
+      issuerSetup.capTableContractDetails.synchronizerId
+    );
+
+    const valuation1 = createTestValuationData({
+      id: generateTestId('valuation-1'),
+      stock_class_id: stockSecurity.stockClassId,
+      price_per_share: { amount: '1.50', currency: 'USD' },
+      effective_date: '2024-01-01',
+    });
+    const valuation2 = createTestValuationData({
+      id: generateTestId('valuation-2'),
+      stock_class_id: stockSecurity.stockClassId,
+      price_per_share: { amount: '2.25', currency: 'USD' },
+      effective_date: '2024-06-01',
+    });
+
+    const batch = ctx.ocp.OpenCapTable.capTable.update({
+      capTableContractId: stockSecurity.capTableContractId,
+      capTableContractDetails,
+      actAs: [ctx.issuerParty],
+    });
+
+    const result = await batch.create('valuation', valuation1).create('valuation', valuation2).execute();
+
+    expect(result.createdCids).toHaveLength(2);
+    expect(result.updatedCapTableCid).toBeTruthy();
+
+    const ocfResults = await Promise.all(
+      result.createdCids.map(async (cid) =>
+        ctx.ocp.OpenCapTable.valuation.get({
+          contractId: extractContractIdString(cid),
+        })
+      )
+    );
+    expect(ocfResults.map((ocf) => ocf.data.id)).toEqual([valuation1.id, valuation2.id]);
   });
 
   /**
@@ -330,9 +431,64 @@ createIntegrationTestSuite('Valuation and Vesting types via batch API', (getCont
   /**
    * Test: Create valuation and vesting types together in a batch.
    *
-   * Previously skipped: This test includes valuation which requires valid stock class references.
+   * This test includes valuation, which requires valid stock class references.
    */
   test('creates valuation and vesting types together in batch', async () => {
-    // This test includes valuation which requires a valid stock_class_id.
+    const ctx = getContext();
+
+    const issuerSetup = await setupTestIssuer(ctx.ocp, {
+      systemOperatorParty: ctx.systemOperatorParty,
+      ocpFactoryContractId: ctx.ocpFactoryContractId,
+      issuerParty: ctx.issuerParty,
+    });
+
+    const stockSecurity = await setupStockSecurity(ctx.ocp, {
+      issuerContractId: issuerSetup.issuerContractId,
+      issuerParty: ctx.issuerParty,
+      capTableContractDetails: issuerSetup.capTableContractDetails,
+    });
+    const capTableContractDetails = await getUpdatedCapTableDetails(
+      ctx,
+      stockSecurity.capTableContractId,
+      issuerSetup.capTableContractDetails.synchronizerId
+    );
+
+    const valuationData = createTestValuationData({
+      id: generateTestId('valuation-combined'),
+      stock_class_id: stockSecurity.stockClassId,
+      price_per_share: { amount: '3.00', currency: 'USD' },
+    });
+    const vestingStartData = createTestVestingStartData({
+      id: generateTestId('vesting-start-combined'),
+      security_id: stockSecurity.securityId,
+      vesting_condition_id: 'combined-start-condition',
+    });
+    const vestingAccelerationData = createTestVestingAccelerationData({
+      id: generateTestId('vesting-accel-combined'),
+      security_id: stockSecurity.securityId,
+      quantity: '10000',
+      reason_text: 'Combined batch acceleration test',
+    });
+
+    const batch = ctx.ocp.OpenCapTable.capTable.update({
+      capTableContractId: stockSecurity.capTableContractId,
+      capTableContractDetails,
+      actAs: [ctx.issuerParty],
+    });
+
+    const result = await batch
+      .create('valuation', valuationData)
+      .create('vestingStart', vestingStartData)
+      .create('vestingAcceleration', vestingAccelerationData)
+      .execute();
+
+    expect(result.createdCids).toHaveLength(3);
+    expect(result.updatedCapTableCid).toBeTruthy();
+
+    const valuationResult = await ctx.ocp.OpenCapTable.valuation.get({
+      contractId: extractContractIdString(result.createdCids[0]),
+    });
+    expect(valuationResult.data.object_type).toBe('VALUATION');
+    expect(valuationResult.data.stock_class_id).toBe(stockSecurity.stockClassId);
   });
 });

--- a/test/integration/entities/valuationVesting.integration.test.ts
+++ b/test/integration/entities/valuationVesting.integration.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for Valuation and Vesting types via batch API.
  *
  * Tests the batch API for:
- * - Valuation (409A valuations) - SKIPPED: requires existing stock class
+ * - Valuation (409A valuations) - Previously skipped: requires existing stock class
  * - VestingStart (when vesting schedule begins)
  * - VestingEvent (milestone-based vesting events)
  * - VestingAcceleration (accelerated vesting due to M&A, etc.)
@@ -41,11 +41,11 @@ createIntegrationTestSuite('Valuation and Vesting types via batch API', (getCont
   /**
    * Test: Create a valuation (409A) via batch API.
    *
-   * SKIPPED: Valuations require a valid stock_class_id that exists in the DAML contract.
+   * Previously skipped: Valuations require a valid stock_class_id that exists in the DAML contract.
    * Stock class creation via batch API has numeric encoding issues, so we cannot easily
    * create the prerequisite stock class needed for this test.
    */
-  test.skip('creates valuation entity via batch API', async () => {
+  test('creates valuation entity via batch API', async () => {
     // This test requires a valid stock_class_id. Stock class creation via batch API
     // has numeric encoding issues (JSON API expects Numeric as objects but receives strings).
     // See capTableBatch.integration.test.ts for details on this limitation.
@@ -54,9 +54,9 @@ createIntegrationTestSuite('Valuation and Vesting types via batch API', (getCont
   /**
    * Test: Create multiple valuations in a single batch.
    *
-   * SKIPPED: See above - valuations require valid stock class references.
+   * Previously skipped: See above - valuations require valid stock class references.
    */
-  test.skip('creates multiple valuations in batch', async () => {
+  test('creates multiple valuations in batch', async () => {
     // This test requires valid stock_class_ids for each valuation.
   });
 
@@ -330,9 +330,9 @@ createIntegrationTestSuite('Valuation and Vesting types via batch API', (getCont
   /**
    * Test: Create valuation and vesting types together in a batch.
    *
-   * SKIPPED: This test includes valuation which requires valid stock class references.
+   * Previously skipped: This test includes valuation which requires valid stock class references.
    */
-  test.skip('creates valuation and vesting types together in batch', async () => {
+  test('creates valuation and vesting types together in batch', async () => {
     // This test includes valuation which requires a valid stock_class_id.
   });
 });

--- a/test/integration/entities/valuationVesting.integration.test.ts
+++ b/test/integration/entities/valuationVesting.integration.test.ts
@@ -17,13 +17,14 @@
  * ```
  */
 
-import { createIntegrationTestSuite, type IntegrationTestContext } from '../setup';
+import { createIntegrationTestSuite } from '../setup';
 import {
   createTestValuationData,
   createTestVestingAccelerationData,
   createTestVestingEventData,
   createTestVestingStartData,
   generateTestId,
+  getCapTableDetails,
   requireCreatedEventBlob,
   setupStockSecurity,
   setupTestIssuer,
@@ -34,20 +35,6 @@ function extractContractIdString(cid: { value: unknown }): string {
     throw new Error(`Expected contractId.value to be a string, got ${typeof cid.value}`);
   }
   return cid.value;
-}
-
-async function getUpdatedCapTableDetails(ctx: IntegrationTestContext, contractId: string, synchronizerId: string) {
-  const events = await ctx.ocp.ledger.getEventsByContractId({ contractId });
-  if (!events.created?.createdEvent) {
-    throw new Error('Failed to get CapTable created event');
-  }
-
-  return {
-    templateId: events.created.createdEvent.templateId,
-    contractId,
-    createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
-    synchronizerId,
-  };
 }
 
 createIntegrationTestSuite('Valuation and Vesting types via batch API', (getContext) => {
@@ -70,8 +57,8 @@ createIntegrationTestSuite('Valuation and Vesting types via batch API', (getCont
       issuerParty: ctx.issuerParty,
       capTableContractDetails: issuerSetup.capTableContractDetails,
     });
-    const capTableContractDetails = await getUpdatedCapTableDetails(
-      ctx,
+    const capTableContractDetails = await getCapTableDetails(
+      ctx.ocp,
       stockSecurity.capTableContractId,
       issuerSetup.capTableContractDetails.synchronizerId
     );
@@ -121,8 +108,8 @@ createIntegrationTestSuite('Valuation and Vesting types via batch API', (getCont
       issuerParty: ctx.issuerParty,
       capTableContractDetails: issuerSetup.capTableContractDetails,
     });
-    const capTableContractDetails = await getUpdatedCapTableDetails(
-      ctx,
+    const capTableContractDetails = await getCapTableDetails(
+      ctx.ocp,
       stockSecurity.capTableContractId,
       issuerSetup.capTableContractDetails.synchronizerId
     );
@@ -447,8 +434,8 @@ createIntegrationTestSuite('Valuation and Vesting types via batch API', (getCont
       issuerParty: ctx.issuerParty,
       capTableContractDetails: issuerSetup.capTableContractDetails,
     });
-    const capTableContractDetails = await getUpdatedCapTableDetails(
-      ctx,
+    const capTableContractDetails = await getCapTableDetails(
+      ctx.ocp,
       stockSecurity.capTableContractId,
       issuerSetup.capTableContractDetails.synchronizerId
     );

--- a/test/integration/production/productionDataRoundtrip.integration.test.ts
+++ b/test/integration/production/productionDataRoundtrip.integration.test.ts
@@ -92,7 +92,7 @@ function extractContractIdString(cid: { value: unknown }): string {
 async function getUpdatedCapTableDetails(ctx: IntegrationTestContext, contractId: string, synchronizerId: string) {
   const events = await ctx.ocp.ledger.getEventsByContractId({ contractId });
   if (!events.created?.createdEvent) {
-    throw new Error('Failed to get CapTable created event');
+    throw new Error(`Failed to get CapTable created event for contract ${contractId}`);
   }
 
   return {

--- a/test/integration/production/productionDataRoundtrip.integration.test.ts
+++ b/test/integration/production/productionDataRoundtrip.integration.test.ts
@@ -25,9 +25,11 @@ import {
 import { normalizeOcfData } from '../../../src/utils/planSecurityAliases';
 import { validateOcfObject } from '../../utils/ocfSchemaValidator';
 import { loadProductionFixture, loadSyntheticFixture, stripSourceMetadata } from '../../utils/productionFixtures';
-import { createIntegrationTestSuite } from '../setup';
+import { createIntegrationTestSuite, type IntegrationTestContext } from '../setup';
 import {
+  createTestStockPlanData,
   generateTestId,
+  requireCreatedEventBlob,
   setupConvertibleSecurity,
   setupEquityCompensationSecurity,
   setupStockSecurity,
@@ -87,6 +89,58 @@ function extractContractIdString(cid: { value: unknown }): string {
   return cid.value as string;
 }
 
+async function getUpdatedCapTableDetails(ctx: IntegrationTestContext, contractId: string, synchronizerId: string) {
+  const events = await ctx.ocp.ledger.getEventsByContractId({ contractId });
+  if (!events.created?.createdEvent) {
+    throw new Error('Failed to get CapTable created event');
+  }
+
+  return {
+    templateId: events.created.createdEvent.templateId,
+    contractId,
+    createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
+    synchronizerId,
+  };
+}
+
+async function createStockPlanPrerequisite(
+  ctx: IntegrationTestContext,
+  params: {
+    capTableContractId: string;
+    capTableContractDetails: {
+      templateId: string;
+      contractId: string;
+      createdEventBlob: string;
+      synchronizerId: string;
+    };
+    issuerParty: string;
+    stockClassId: string;
+    stockPlanId?: string;
+  }
+) {
+  const stockPlanData = createTestStockPlanData({
+    id: params.stockPlanId,
+    stock_class_ids: [params.stockClassId],
+  });
+
+  const batch = ctx.ocp.OpenCapTable.capTable.update({
+    capTableContractId: params.capTableContractId,
+    capTableContractDetails: params.capTableContractDetails,
+    actAs: [params.issuerParty],
+  });
+  const result = await batch.create('stockPlan', stockPlanData).execute();
+
+  return {
+    stockPlanId: stockPlanData.id,
+    capTableContractId: result.updatedCapTableCid,
+    capTableContractDetails: await getUpdatedCapTableDetails(
+      ctx,
+      result.updatedCapTableCid,
+      params.capTableContractDetails.synchronizerId
+    ),
+  };
+}
+
 // =============================================================================
 // PRODUCTION FIXTURES - Tests using real anonymized data (26 types)
 // =============================================================================
@@ -118,11 +172,11 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
     });
 
     /**
-     * SKIPPED: StockClass uses nested Numeric fields (price_per_share, par_value).
+     * Previously skipped: StockClass uses nested Numeric fields (price_per_share, par_value).
      * The DAML JSON API v2 has encoding issues with nested Numeric fields.
      * See CLAUDE.md "DAML JSON API v2 Nested Numeric Encoding" for details.
      */
-    test.skip('Stock Class round-trips correctly', async () => {
+    test('Stock Class round-trips correctly', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -145,11 +199,11 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
     });
 
     /**
-     * SKIPPED: Valuation uses nested Numeric fields (price_per_share).
+     * Previously skipped: Valuation uses nested Numeric fields (price_per_share).
      * The DAML JSON API v2 has encoding issues with nested Numeric fields.
      * See CLAUDE.md "DAML JSON API v2 Nested Numeric Encoding" for details.
      */
-    test.skip('Valuation round-trips correctly', async () => {
+    test('Valuation round-trips correctly', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -159,11 +213,24 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadProductionFixture<Record<string, unknown>>('valuation', '409a');
-      const prepared = prepareFixture(fixture, 'valuation');
+      const stockSecurity = await setupStockSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const capTableContractDetails = await getUpdatedCapTableDetails(
+        ctx,
+        stockSecurity.capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
+      const prepared = {
+        ...prepareFixture(fixture, 'valuation'),
+        stock_class_id: stockSecurity.stockClassId,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: stockSecurity.capTableContractId,
+        capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -293,11 +360,11 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
     });
 
     /**
-     * SKIPPED: VestingTerms has complex nested structures (vesting_conditions with portions using Numeric fields).
+     * Previously skipped: VestingTerms has complex nested structures (vesting_conditions with portions using Numeric fields).
      * The batch API's DAML encoding requires fixture format adjustments.
      * TODO: Fix fixture format to match expected DAML structure.
      */
-    test.skip('Vesting Terms round-trips correctly', async () => {
+    test('Vesting Terms round-trips correctly', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -360,11 +427,11 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
 
   describe('Stock Transactions', () => {
     /**
-     * SKIPPED: StockIssuance uses nested Numeric fields (share_price, cost_basis).
+     * Previously skipped: StockIssuance uses nested Numeric fields (share_price, cost_basis).
      * The DAML JSON API v2 has encoding issues with nested Numeric fields.
      * See CLAUDE.md "DAML JSON API v2 Nested Numeric Encoding" for details.
      */
-    test.skip('Stock Issuance round-trips correctly', async () => {
+    test('Stock Issuance round-trips correctly', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -374,11 +441,25 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadProductionFixture<Record<string, unknown>>('stockIssuance', 'founders-stock');
-      const prepared = prepareFixture(fixture, 'stock-issuance');
+      const stockSecurity = await setupStockSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const capTableContractDetails = await getUpdatedCapTableDetails(
+        ctx,
+        stockSecurity.capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
+      const prepared = {
+        ...prepareFixture(fixture, 'stock-issuance'),
+        stakeholder_id: stockSecurity.stakeholderId,
+        stock_class_id: stockSecurity.stockClassId,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: stockSecurity.capTableContractId,
+        capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -522,12 +603,12 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
 
   describe('Convertible Transactions', () => {
     /**
-     * SKIPPED: ConvertibleIssuance has complex nested structures with Numeric fields
+     * Previously skipped: ConvertibleIssuance has complex nested structures with Numeric fields
      * (investment_amount, conversion_valuation_cap).
      * The DAML JSON API v2 has encoding issues with nested Numeric fields.
      * See CLAUDE.md "DAML JSON API v2 Nested Numeric Encoding" for details.
      */
-    test.skip('Convertible Issuance round-trips correctly', async () => {
+    test('Convertible Issuance round-trips correctly', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -537,11 +618,19 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadProductionFixture<Record<string, unknown>>('convertibleIssuance', 'safe-post-money');
-      const prepared = prepareFixture(fixture, 'convertible-issuance');
+      const stakeholder = await setupTestStakeholder(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const prepared = {
+        ...prepareFixture(fixture, 'convertible-issuance'),
+        stakeholder_id: stakeholder.stakeholderData.id,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: stakeholder.newCapTableContractId,
+        capTableContractDetails: stakeholder.newCapTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -550,10 +639,10 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
     });
 
     /**
-     * SKIPPED: ConvertibleCancellation batch API fails with COMMAND_PREPROCESSING_FAILED.
+     * Previously skipped: ConvertibleCancellation batch API fails with COMMAND_PREPROCESSING_FAILED.
      * The DAML contract expects different data structure than what the batch API provides.
      */
-    test.skip('Convertible Cancellation round-trips correctly', async () => {
+    test('Convertible Cancellation round-trips correctly', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -563,11 +652,24 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadProductionFixture<Record<string, unknown>>('convertibleCancellation');
-      const prepared = prepareFixture(fixture, 'convertible-cancel');
+      const convertibleSecurity = await setupConvertibleSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const capTableContractDetails = await getUpdatedCapTableDetails(
+        ctx,
+        convertibleSecurity.capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
+      const prepared = {
+        ...prepareFixture(fixture, 'convertible-cancel'),
+        security_id: convertibleSecurity.securityId,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: convertibleSecurity.capTableContractId,
+        capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -576,10 +678,10 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
     });
 
     /**
-     * SKIPPED: ConvertibleConversion batch API fails with COMMAND_PREPROCESSING_FAILED.
+     * Previously skipped: ConvertibleConversion batch API fails with COMMAND_PREPROCESSING_FAILED.
      * The DAML contract expects different data structure than what the batch API provides.
      */
-    test.skip('Convertible Conversion round-trips correctly', async () => {
+    test('Convertible Conversion round-trips correctly', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -589,11 +691,24 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadProductionFixture<Record<string, unknown>>('convertibleConversion');
-      const prepared = prepareFixture(fixture, 'convertible-conversion');
+      const convertibleSecurity = await setupConvertibleSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const capTableContractDetails = await getUpdatedCapTableDetails(
+        ctx,
+        convertibleSecurity.capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
+      const prepared = {
+        ...prepareFixture(fixture, 'convertible-conversion'),
+        security_id: convertibleSecurity.securityId,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: convertibleSecurity.capTableContractId,
+        capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -653,11 +768,11 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
 
   describe('Equity Compensation Transactions', () => {
     /**
-     * SKIPPED: EquityCompensationIssuance uses nested Numeric fields (exercise_price).
+     * Previously skipped: EquityCompensationIssuance uses nested Numeric fields (exercise_price).
      * The DAML JSON API v2 has encoding issues with nested Numeric fields.
      * See CLAUDE.md "DAML JSON API v2 Nested Numeric Encoding" for details.
      */
-    test.skip('Equity Compensation Issuance round-trips correctly', async () => {
+    test('Equity Compensation Issuance round-trips correctly', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -667,11 +782,35 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadProductionFixture<Record<string, unknown>>('equityCompensationIssuance', 'option-iso');
+      const eqCompSecurity = await setupEquityCompensationSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      let { capTableContractId } = eqCompSecurity;
+      let capTableContractDetails = await getUpdatedCapTableDetails(
+        ctx,
+        capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
       const prepared = prepareFixture(fixture, 'equity-compensation-issuance');
+      delete prepared.vesting_terms_id;
+      prepared.stakeholder_id = eqCompSecurity.stakeholderId;
+      prepared.stock_class_id = eqCompSecurity.stockClassId;
+      if (typeof prepared.stock_plan_id === 'string') {
+        const stockPlan = await createStockPlanPrerequisite(ctx, {
+          capTableContractId,
+          capTableContractDetails,
+          issuerParty: ctx.issuerParty,
+          stockClassId: eqCompSecurity.stockClassId,
+          stockPlanId: prepared.stock_plan_id,
+        });
+        ({ capTableContractId, capTableContractDetails } = stockPlan);
+      }
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId,
+        capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -798,10 +937,10 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
     });
 
     /**
-     * SKIPPED: StockClassAuthorizedSharesAdjustment batch API fails with COMMAND_PREPROCESSING_FAILED.
+     * Previously skipped: StockClassAuthorizedSharesAdjustment batch API fails with COMMAND_PREPROCESSING_FAILED.
      * The DAML contract expects different data structure than what the batch API provides.
      */
-    test.skip('Stock Class Authorized Shares Adjustment round-trips correctly', async () => {
+    test('Stock Class Authorized Shares Adjustment round-trips correctly', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -811,11 +950,24 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadProductionFixture<Record<string, unknown>>('stockClassAuthorizedSharesAdjustment');
-      const prepared = prepareFixture(fixture, 'stock-class-shares-adj');
+      const stockSecurity = await setupStockSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const capTableContractDetails = await getUpdatedCapTableDetails(
+        ctx,
+        stockSecurity.capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
+      const prepared = {
+        ...prepareFixture(fixture, 'stock-class-shares-adj'),
+        stock_class_id: stockSecurity.stockClassId,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: stockSecurity.capTableContractId,
+        capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -824,10 +976,10 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
     });
 
     /**
-     * SKIPPED: StockPlanPoolAdjustment batch API fails with COMMAND_PREPROCESSING_FAILED.
+     * Previously skipped: StockPlanPoolAdjustment batch API fails with COMMAND_PREPROCESSING_FAILED.
      * The DAML contract expects different data structure than what the batch API provides.
      */
-    test.skip('Stock Plan Pool Adjustment round-trips correctly', async () => {
+    test('Stock Plan Pool Adjustment round-trips correctly', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -837,11 +989,32 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadProductionFixture<Record<string, unknown>>('stockPlanPoolAdjustment');
-      const prepared = prepareFixture(fixture, 'stock-plan-pool-adj');
+      const stockSecurity = await setupStockSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const stockSecurityCapTableDetails = await getUpdatedCapTableDetails(
+        ctx,
+        stockSecurity.capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
+      const fixturePrepared = prepareFixture(fixture, 'stock-plan-pool-adj');
+      const stockPlan = await createStockPlanPrerequisite(ctx, {
+        capTableContractId: stockSecurity.capTableContractId,
+        capTableContractDetails: stockSecurityCapTableDetails,
+        issuerParty: ctx.issuerParty,
+        stockClassId: stockSecurity.stockClassId,
+        stockPlanId: typeof fixturePrepared.stock_plan_id === 'string' ? fixturePrepared.stock_plan_id : undefined,
+      });
+      const prepared = {
+        ...fixturePrepared,
+        stock_plan_id: stockPlan.stockPlanId,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: stockPlan.capTableContractId,
+        capTableContractDetails: stockPlan.capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -850,11 +1023,11 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
     });
 
     /**
-     * SKIPPED: StockClassSplit uses OcfRatio which has nested Numeric fields.
+     * Previously skipped: StockClassSplit uses OcfRatio which has nested Numeric fields.
      * The DAML JSON API v2 has encoding issues with nested Numeric fields.
      * See CLAUDE.md "DAML JSON API v2 Nested Numeric Encoding" for details.
      */
-    test.skip('Stock Class Split round-trips correctly', async () => {
+    test('Stock Class Split round-trips correctly', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -864,11 +1037,24 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadProductionFixture<Record<string, unknown>>('stockClassSplit');
-      const prepared = prepareFixture(fixture, 'stock-class-split');
+      const stockSecurity = await setupStockSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const capTableContractDetails = await getUpdatedCapTableDetails(
+        ctx,
+        stockSecurity.capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
+      const prepared = {
+        ...prepareFixture(fixture, 'stock-class-split'),
+        stock_class_id: stockSecurity.stockClassId,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: stockSecurity.capTableContractId,
+        capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -883,11 +1069,11 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
 
   describe('Warrant Transactions', () => {
     /**
-     * SKIPPED: WarrantIssuance uses nested Numeric fields (exercise_price, purchase_price).
+     * Previously skipped: WarrantIssuance uses nested Numeric fields (exercise_price, purchase_price).
      * The DAML JSON API v2 has encoding issues with nested Numeric fields.
      * See CLAUDE.md "DAML JSON API v2 Nested Numeric Encoding" for details.
      */
-    test.skip('Warrant Issuance round-trips correctly', async () => {
+    test('Warrant Issuance round-trips correctly', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -897,11 +1083,19 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadProductionFixture<Record<string, unknown>>('warrantIssuance');
-      const prepared = prepareFixture(fixture, 'warrant-issuance');
+      const stakeholder = await setupTestStakeholder(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const prepared = {
+        ...prepareFixture(fixture, 'warrant-issuance'),
+        stakeholder_id: stakeholder.stakeholderData.id,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: stakeholder.newCapTableContractId,
+        capTableContractDetails: stakeholder.newCapTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -1049,10 +1243,10 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
     });
 
     /**
-     * SKIPPED: StockConversion batch API fails with COMMAND_PREPROCESSING_FAILED.
+     * Previously skipped: StockConversion batch API fails with COMMAND_PREPROCESSING_FAILED.
      * The DAML contract expects different data structure than what the batch API provides.
      */
-    test.skip('Stock Conversion round-trips correctly (synthetic)', async () => {
+    test('Stock Conversion round-trips correctly (synthetic)', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -1062,11 +1256,24 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadSyntheticFixture<Record<string, unknown>>('stockConversion');
-      const prepared = prepareFixture(fixture, 'stock-conversion');
+      const stockSecurity = await setupStockSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const capTableContractDetails = await getUpdatedCapTableDetails(
+        ctx,
+        stockSecurity.capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
+      const prepared = {
+        ...prepareFixture(fixture, 'stock-conversion'),
+        security_id: stockSecurity.securityId,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: stockSecurity.capTableContractId,
+        capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -1378,10 +1585,10 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
     });
 
     /**
-     * SKIPPED: EquityCompensationRelease batch API fails with COMMAND_PREPROCESSING_FAILED.
+     * Previously skipped: EquityCompensationRelease batch API fails with COMMAND_PREPROCESSING_FAILED.
      * The DAML contract expects different data structure than what the batch API provides.
      */
-    test.skip('Equity Compensation Release round-trips correctly (synthetic)', async () => {
+    test('Equity Compensation Release round-trips correctly (synthetic)', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -1391,11 +1598,24 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadSyntheticFixture<Record<string, unknown>>('equityCompensationRelease');
-      const prepared = prepareFixture(fixture, 'equity-release');
+      const eqCompSecurity = await setupEquityCompensationSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const capTableContractDetails = await getUpdatedCapTableDetails(
+        ctx,
+        eqCompSecurity.capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
+      const prepared = {
+        ...prepareFixture(fixture, 'equity-release'),
+        security_id: eqCompSecurity.securityId,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: eqCompSecurity.capTableContractId,
+        capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -1404,10 +1624,10 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
     });
 
     /**
-     * SKIPPED: EquityCompensationRepricing batch API fails with COMMAND_PREPROCESSING_FAILED.
+     * Previously skipped: EquityCompensationRepricing batch API fails with COMMAND_PREPROCESSING_FAILED.
      * The DAML contract expects different data structure than what the batch API provides.
      */
-    test.skip('Equity Compensation Repricing round-trips correctly (synthetic)', async () => {
+    test('Equity Compensation Repricing round-trips correctly (synthetic)', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -1417,11 +1637,24 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadSyntheticFixture<Record<string, unknown>>('equityCompensationRepricing');
-      const prepared = prepareFixture(fixture, 'equity-repricing');
+      const eqCompSecurity = await setupEquityCompensationSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const capTableContractDetails = await getUpdatedCapTableDetails(
+        ctx,
+        eqCompSecurity.capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
+      const prepared = {
+        ...prepareFixture(fixture, 'equity-repricing'),
+        security_id: eqCompSecurity.securityId,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: eqCompSecurity.capTableContractId,
+        capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -1558,10 +1791,10 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
     });
 
     /**
-     * SKIPPED: WarrantExercise batch API fails with COMMAND_PREPROCESSING_FAILED.
+     * Previously skipped: WarrantExercise batch API fails with COMMAND_PREPROCESSING_FAILED.
      * The DAML contract expects different data structure than what the batch API provides.
      */
-    test.skip('Warrant Exercise round-trips correctly (synthetic)', async () => {
+    test('Warrant Exercise round-trips correctly (synthetic)', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -1571,11 +1804,24 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadSyntheticFixture<Record<string, unknown>>('warrantExercise');
-      const prepared = prepareFixture(fixture, 'warrant-exercise');
+      const warrantSecurity = await setupWarrantSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const capTableContractDetails = await getUpdatedCapTableDetails(
+        ctx,
+        warrantSecurity.capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
+      const prepared = {
+        ...prepareFixture(fixture, 'warrant-exercise'),
+        security_id: warrantSecurity.securityId,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: warrantSecurity.capTableContractId,
+        capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -1812,10 +2058,10 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
     });
 
     /**
-     * SKIPPED: StockPlanReturnToPool batch API fails with COMMAND_PREPROCESSING_FAILED.
+     * Previously skipped: StockPlanReturnToPool batch API fails with COMMAND_PREPROCESSING_FAILED.
      * The DAML contract expects different data structure than what the batch API provides.
      */
-    test.skip('Stock Plan Return to Pool round-trips correctly (synthetic)', async () => {
+    test('Stock Plan Return to Pool round-trips correctly (synthetic)', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -1825,11 +2071,33 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadSyntheticFixture<Record<string, unknown>>('stockPlanReturnToPool');
-      const prepared = prepareFixture(fixture, 'stock-plan-return');
+      const eqCompSecurity = await setupEquityCompensationSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const eqCompCapTableDetails = await getUpdatedCapTableDetails(
+        ctx,
+        eqCompSecurity.capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
+      const fixturePrepared = prepareFixture(fixture, 'stock-plan-return');
+      const stockPlan = await createStockPlanPrerequisite(ctx, {
+        capTableContractId: eqCompSecurity.capTableContractId,
+        capTableContractDetails: eqCompCapTableDetails,
+        issuerParty: ctx.issuerParty,
+        stockClassId: eqCompSecurity.stockClassId,
+        stockPlanId: typeof fixturePrepared.stock_plan_id === 'string' ? fixturePrepared.stock_plan_id : undefined,
+      });
+      const prepared = {
+        ...fixturePrepared,
+        security_id: eqCompSecurity.securityId,
+        stock_plan_id: stockPlan.stockPlanId,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: stockPlan.capTableContractId,
+        capTableContractDetails: stockPlan.capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 
@@ -1840,11 +2108,11 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
 
   describe('Synthetic Fixtures - Corporate Actions', () => {
     /**
-     * SKIPPED: StockClassConversionRatioAdjustment uses OcfRatioConversionMechanism with nested Numeric fields.
+     * Previously skipped: StockClassConversionRatioAdjustment uses OcfRatioConversionMechanism with nested Numeric fields.
      * The DAML JSON API v2 has encoding issues with nested Numeric fields.
      * See CLAUDE.md "DAML JSON API v2 Nested Numeric Encoding" for details.
      */
-    test.skip('Stock Class Conversion Ratio Adjustment round-trips correctly (synthetic)', async () => {
+    test('Stock Class Conversion Ratio Adjustment round-trips correctly (synthetic)', async () => {
       const ctx = getContext();
 
       const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -1854,11 +2122,24 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
       });
 
       const fixture = loadSyntheticFixture<Record<string, unknown>>('stockClassConversionRatioAdjustment');
-      const prepared = prepareFixture(fixture, 'stock-class-conv-ratio-adj');
+      const stockSecurity = await setupStockSecurity(ctx.ocp, {
+        issuerContractId: issuerSetup.issuerContractId,
+        issuerParty: ctx.issuerParty,
+        capTableContractDetails: issuerSetup.capTableContractDetails,
+      });
+      const capTableContractDetails = await getUpdatedCapTableDetails(
+        ctx,
+        stockSecurity.capTableContractId,
+        issuerSetup.capTableContractDetails.synchronizerId
+      );
+      const prepared = {
+        ...prepareFixture(fixture, 'stock-class-conv-ratio-adj'),
+        stock_class_id: stockSecurity.stockClassId,
+      };
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
-        capTableContractId: issuerSetup.issuerContractId,
-        capTableContractDetails: issuerSetup.capTableContractDetails,
+        capTableContractId: stockSecurity.capTableContractId,
+        capTableContractDetails,
         actAs: [ctx.issuerParty],
       });
 

--- a/test/integration/utils/setupTestData.ts
+++ b/test/integration/utils/setupTestData.ts
@@ -81,6 +81,27 @@ export function generateTestId(prefix: string): string {
   return `${prefix}-${timestamp}-${random}`;
 }
 
+/** Get updated CapTable contract details after a batch operation. */
+export async function getCapTableDetails(
+  ocp: OcpClient,
+  capTableContractId: string,
+  synchronizerId: string
+): Promise<DisclosedContract> {
+  const capTableEvents = await ocp.ledger.getEventsByContractId({
+    contractId: capTableContractId,
+  });
+  if (!capTableEvents.created?.createdEvent) {
+    throw new Error(`Failed to get CapTable created event for contract ${capTableContractId}`);
+  }
+
+  return {
+    templateId: capTableEvents.created.createdEvent.templateId,
+    contractId: capTableContractId,
+    createdEventBlob: requireCreatedEventBlob(capTableEvents.created.createdEvent),
+    synchronizerId,
+  };
+}
+
 /**
  * Generate a date string in ISO format (YYYY-MM-DD).
  *

--- a/test/integration/utils/setupTestData.ts
+++ b/test/integration/utils/setupTestData.ts
@@ -949,11 +949,16 @@ export function createTestConvertibleIssuanceData(
 }
 
 /** Helper to extract a contract ID from a createdCids array by type tag. */
-function extractCreatedCid(createdCids: Array<Record<string, string>>, tagPrefix: string): string {
+function extractCreatedCid(createdCids: Array<Record<string, unknown>>, tagPrefix: string): string {
   for (const cid of createdCids) {
-    for (const [key, value] of Object.entries(cid)) {
-      if (key.startsWith(tagPrefix)) {
-        return value;
+    const { tag, value: taggedValue } = cid;
+    if (typeof tag === 'string' && tag.startsWith(tagPrefix) && typeof taggedValue === 'string') {
+      return taggedValue;
+    }
+
+    for (const [key, entryValue] of Object.entries(cid)) {
+      if (key.startsWith(tagPrefix) && typeof entryValue === 'string') {
+        return entryValue;
       }
     }
   }

--- a/test/integration/workflows/capTableWorkflow.integration.test.ts
+++ b/test/integration/workflows/capTableWorkflow.integration.test.ts
@@ -237,9 +237,7 @@ createIntegrationTestSuite('Cap Table Workflow', (getContext) => {
    *
    * Demonstrates creating a 409A valuation which is required for equity compensation pricing.
    *
-   * Previously skipped: This test requires a valid stock_class_id that references an existing stock class.
-   * Stock class creation has numeric encoding issues with JSON API v2, so we can't create the
-   * prerequisite stock class. When stock class creation is fixed, this test can be re-enabled.
+   * Creates a real stock security first so the valuation references an existing stock class.
    */
   test('creates valuation entity', async () => {
     const ctx = getContext();
@@ -256,16 +254,11 @@ createIntegrationTestSuite('Cap Table Workflow', (getContext) => {
       issuerParty: ctx.issuerParty,
       capTableContractDetails: issuerSetup.capTableContractDetails,
     });
-    const capTableEvents = await ctx.ocp.ledger.getEventsByContractId({ contractId: stockSecurity.capTableContractId });
-    if (!capTableEvents.created?.createdEvent) {
-      throw new Error('Failed to get CapTable created event');
-    }
-    const capTableContractDetails = {
-      templateId: capTableEvents.created.createdEvent.templateId,
-      contractId: stockSecurity.capTableContractId,
-      createdEventBlob: requireCreatedEventBlob(capTableEvents.created.createdEvent),
-      synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
-    };
+    const capTableContractDetails = await getUpdatedCapTableDetails(
+      ctx.ocp,
+      stockSecurity.capTableContractId,
+      issuerSetup.capTableContractDetails.synchronizerId
+    );
 
     const valuationData = createTestValuationData({
       id: generateTestId('valuation'),

--- a/test/integration/workflows/capTableWorkflow.integration.test.ts
+++ b/test/integration/workflows/capTableWorkflow.integration.test.ts
@@ -14,7 +14,6 @@
  * ```
  */
 
-import type { DisclosedContract } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/schemas/api/commands';
 import { validateOcfObject } from '../../utils/ocfSchemaValidator';
 import { createIntegrationTestSuite } from '../setup';
 import {
@@ -23,7 +22,7 @@ import {
   createTestValuationData,
   createTestVestingTermsData,
   generateTestId,
-  requireCreatedEventBlob,
+  getCapTableDetails,
   setupStockSecurity,
   setupTestIssuer,
 } from '../utils';
@@ -104,7 +103,7 @@ createIntegrationTestSuite('Cap Table Workflow', (getContext) => {
     expect(result1.updatedCapTableCid).toBeTruthy();
 
     // Step 3: Create vesting terms using the new CapTable
-    const newCapTableContractDetails = await getUpdatedCapTableDetails(
+    const newCapTableContractDetails = await getCapTableDetails(
       ctx.ocp,
       result1.updatedCapTableCid,
       issuerSetup.capTableContractDetails.synchronizerId
@@ -216,7 +215,7 @@ createIntegrationTestSuite('Cap Table Workflow', (getContext) => {
 
       // Update for next iteration
       currentCapTableCid = result.updatedCapTableCid;
-      currentCapTableDetails = await getUpdatedCapTableDetails(
+      currentCapTableDetails = await getCapTableDetails(
         ctx.ocp,
         currentCapTableCid,
         issuerSetup.capTableContractDetails.synchronizerId
@@ -254,7 +253,7 @@ createIntegrationTestSuite('Cap Table Workflow', (getContext) => {
       issuerParty: ctx.issuerParty,
       capTableContractDetails: issuerSetup.capTableContractDetails,
     });
-    const capTableContractDetails = await getUpdatedCapTableDetails(
+    const capTableContractDetails = await getCapTableDetails(
       ctx.ocp,
       stockSecurity.capTableContractId,
       issuerSetup.capTableContractDetails.synchronizerId
@@ -356,7 +355,7 @@ createIntegrationTestSuite('Cap Table Workflow', (getContext) => {
     expect(createResult.createdCids).toHaveLength(2);
 
     // Get updated CapTable details
-    const newCapTableDetails = await getUpdatedCapTableDetails(
+    const newCapTableDetails = await getCapTableDetails(
       ctx.ocp,
       createResult.updatedCapTableCid,
       issuerSetup.capTableContractDetails.synchronizerId
@@ -391,23 +390,3 @@ createIntegrationTestSuite('Cap Table Workflow', (getContext) => {
     expect(editedOcf.data.name.legal_name).toBe('Successfully Edited');
   });
 });
-
-/** Helper to get updated CapTable contract details after a batch operation. */
-async function getUpdatedCapTableDetails(
-  ocp: Parameters<typeof setupTestIssuer>[0],
-  capTableContractId: string,
-  synchronizerId: string
-): Promise<DisclosedContract> {
-  const capTableEvents = await ocp.ledger.getEventsByContractId({
-    contractId: capTableContractId,
-  });
-  if (!capTableEvents.created?.createdEvent) {
-    throw new Error('Failed to get CapTable created event');
-  }
-  return {
-    templateId: capTableEvents.created.createdEvent.templateId,
-    contractId: capTableContractId,
-    createdEventBlob: requireCreatedEventBlob(capTableEvents.created.createdEvent),
-    synchronizerId,
-  };
-}

--- a/test/integration/workflows/capTableWorkflow.integration.test.ts
+++ b/test/integration/workflows/capTableWorkflow.integration.test.ts
@@ -24,6 +24,7 @@ import {
   createTestVestingTermsData,
   generateTestId,
   requireCreatedEventBlob,
+  setupStockSecurity,
   setupTestIssuer,
 } from '../utils';
 
@@ -236,11 +237,11 @@ createIntegrationTestSuite('Cap Table Workflow', (getContext) => {
    *
    * Demonstrates creating a 409A valuation which is required for equity compensation pricing.
    *
-   * SKIPPED: This test requires a valid stock_class_id that references an existing stock class.
+   * Previously skipped: This test requires a valid stock_class_id that references an existing stock class.
    * Stock class creation has numeric encoding issues with JSON API v2, so we can't create the
    * prerequisite stock class. When stock class creation is fixed, this test can be re-enabled.
    */
-  test.skip('creates valuation entity', async () => {
+  test('creates valuation entity', async () => {
     const ctx = getContext();
 
     const issuerSetup = await setupTestIssuer(ctx.ocp, {
@@ -249,21 +250,34 @@ createIntegrationTestSuite('Cap Table Workflow', (getContext) => {
       issuerParty: ctx.issuerParty,
     });
 
-    // Create a valuation (normally this would reference a real stock class ID)
-    // For testing purposes, we'll use a placeholder stock class ID
-    const stockClassId = generateTestId('stock-class');
+    // Create a real stock class first; DAML validates stock_class_id references.
+    const stockSecurity = await setupStockSecurity(ctx.ocp, {
+      issuerContractId: issuerSetup.issuerContractId,
+      issuerParty: ctx.issuerParty,
+      capTableContractDetails: issuerSetup.capTableContractDetails,
+    });
+    const capTableEvents = await ctx.ocp.ledger.getEventsByContractId({ contractId: stockSecurity.capTableContractId });
+    if (!capTableEvents.created?.createdEvent) {
+      throw new Error('Failed to get CapTable created event');
+    }
+    const capTableContractDetails = {
+      templateId: capTableEvents.created.createdEvent.templateId,
+      contractId: stockSecurity.capTableContractId,
+      createdEventBlob: requireCreatedEventBlob(capTableEvents.created.createdEvent),
+      synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
+    };
 
     const valuationData = createTestValuationData({
       id: generateTestId('valuation'),
-      stock_class_id: stockClassId,
+      stock_class_id: stockSecurity.stockClassId,
       price_per_share: { amount: '2.50', currency: 'USD' },
       provider: 'Valuation Co',
       valuation_type: '409A',
     });
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
-      capTableContractId: issuerSetup.issuerContractId,
-      capTableContractDetails: issuerSetup.capTableContractDetails,
+      capTableContractId: stockSecurity.capTableContractId,
+      capTableContractDetails,
       actAs: [ctx.issuerParty],
     });
 


### PR DESCRIPTION
## Summary

Fixes ENG-486 by enabling and repairing the currently skipped integration coverage in `ocp-canton-sdk`.

## What changed

- Re-enabled formerly skipped integration tests across production round-trip, entity, and workflow coverage.
- Added real prerequisite setup for tests that previously submitted stale fixture IDs directly to the ledger.
- Updated synthetic/production fixtures to match the current OCF schemas and batch API expectations.
- Made `createdCids` extraction compatible with both tagged `{ tag, value }` results and older keyed result shapes.
- Cleaned stale `SKIPPED:` comment markers now that the tests are active.

## Validation

- `npm run lint`
- `npm run format`
- `npm run test:ci` (52 suites, 1665 tests)
- `npm run test:integration:ci -- test/integration/entities/exerciseConversionTypes.integration.test.ts test/integration/entities/stockClassAdjustments.integration.test.ts test/integration/entities/valuationVesting.integration.test.ts test/integration/production/productionDataRoundtrip.integration.test.ts test/integration/workflows/capTableWorkflow.integration.test.ts` (5 suites, 75 tests)
- `rg "test\\.skip|describe\\.skip|it\\.skip|test\\.only|describe\\.only|it\\.only|SKIPPED:" test/integration` returned no matches

Linear: ENG-486

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test fixtures and integration tests; production SDK/runtime paths are not modified.
> 
> **Overview**
> Re-enables integration coverage that was previously skipped (ENG-486) by wiring tests through real ledger prerequisites instead of posting fixtures with fake `security_id` / `stock_class_id` values.
> 
> **Test harness:** Shared `getCapTableDetails` in integration utils (replacing duplicated helpers), plus `createStockPlanPrerequisite` for equity-plan flows. `extractCreatedCid` now accepts tagged `{ tag, value }` batch results as well as legacy keyed shapes.
> 
> **Fixtures:** Synthetic/production JSON updated for current OCF/batch shapes—e.g. `quantity_converted`, `new_exercise_price`, `settlement_date`, `trigger_id` on warrant exercise, `security_id` on plan return-to-pool, and removal of unsupported split approval-date fields.
> 
> **Behavior under test:** Stock class split with `board_approval_date` now asserts client-side rejection (not OCF/DAML). Valuation, exercise/conversion, round-trip, and workflow suites run end-to-end against LocalNet with `setupStockSecurity` / warrant / convertible / equity-comp chains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0bca9067812dc6d90f0d10a9492f57ae8e5d859. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to align with revised data structure requirements (removal of approval date fields, field name changes, and new nested objects).
  * Enabled previously skipped integration tests covering warrant exercises, equity compensation, stock conversions, and valuation operations.
  * Refactored test setup with shared helper functions for improved test maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->