### PR TITLE
[codex] Bump Canton node SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "15.3.5",
     "@eslint/eslintrc": "3.3.5",
-    "@fairmint/canton-node-sdk": "0.0.207",
+    "@fairmint/canton-node-sdk": "0.0.208",
     "@fairmint/open-captable-protocol-daml-js": "0.2.161",
     "@types/jest": "30.0.0",
     "@types/jsonwebtoken": "9.0.10",
@@ -75,7 +75,7 @@
     "typescript": "6.0.3"
   },
   "peerDependencies": {
-    "@fairmint/canton-node-sdk": ">=0.0.207 <0.1.0",
+    "@fairmint/canton-node-sdk": ">=0.0.208 <0.1.0",
     "@fairmint/open-captable-protocol-daml-js": ">=0.2.160 <0.3.0"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Bump the dev dependency on `@fairmint/canton-node-sdk` to `0.0.208`.
- Raise the peer dependency floor to `>=0.0.208 <0.1.0`.

## Validation
- `node -e` JSON parse for changed `package.json` files.
- `git diff --check`.
- `npm view @fairmint/canton-node-sdk@0.0.208 version --json`.

## Duplicate-effort check
- Existing PR #393 is active test repair work and does not touch `package.json`.
- Existing Dependabot PR #392 is a broad grouped dependency update and does not include this SDK bump.
- No existing scoped Canton node SDK bump PR was found.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bump with no runtime code changes in this PR; risk is limited to downstream installs needing the new SDK version.
> 
> **Overview**
> Aligns this package with **`@fairmint/canton-node-sdk` `0.0.208`** by updating the dev dependency pin and raising the **peer dependency minimum** from `>=0.0.207` to `>=0.0.208` (upper bound stays `<0.1.0`).
> 
> No source or test changes in this PR—consumers and local dev are expected to install the newer SDK to satisfy peers and stay in sync with Canton node APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4088f89457c18328ea1d078d85495d382cc2d700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to the latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->