### PR TITLE
[codex] Upgrade OCP DAML package

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@apidevtools/json-schema-ref-parser": "15.3.5",
     "@eslint/eslintrc": "3.3.5",
     "@fairmint/canton-node-sdk": "0.0.207",
-    "@fairmint/open-captable-protocol-daml-js": "0.2.161",
+    "@fairmint/open-captable-protocol-daml-js": "0.3.3",
     "@types/jest": "30.0.0",
     "@types/jsonwebtoken": "9.0.10",
     "@types/node": "25.6.0",
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "@fairmint/canton-node-sdk": ">=0.0.207 <0.1.0",
-    "@fairmint/open-captable-protocol-daml-js": ">=0.2.160 <0.3.0"
+    "@fairmint/open-captable-protocol-daml-js": ">=0.3.3 <0.4.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Upgrade `@fairmint/open-captable-protocol-daml-js` dev dependency to `0.3.3`.
- Widen the peer dependency to `>=0.3.3 <0.4.0` so downstream consumers can install the newly published trusted-publishing package.

## Why
`@fairmint/open-captable-protocol-daml-js@0.3.3` is now published as latest. Current downstream installs fail if they combine that package with `@open-captable-protocol/canton@0.5.12` because the published SDK peers on `<0.3.0`.

## Validation
- `git submodule update --init --recursive libs/Open-Cap-Format-OCF`
- `npm install`
- `npm run build`
- `npm run test:ci`
- `npm run format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Peer dependency range change is a semver signal for consumers on 0.2.x; runtime behavior depends on breaking changes in the 0.3.x DAML JS package, though this PR only touches `package.json`.
> 
> **Overview**
> Aligns this SDK with **`@fairmint/open-captable-protocol-daml-js@0.3.3`**, the newly published OCP DAML bindings, so installs are not blocked by an outdated peer range.
> 
> The **devDependency** moves from `0.2.161` to **`0.3.3`**, and **peerDependencies** are widened from `>=0.2.160 <0.3.0` to **`>=0.3.3 <0.4.0`**, letting downstream apps use the latest trusted-publishing package alongside current `@open-captable-protocol/canton` releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9c74ee60fba9c4b71949a989ab0d119775bc0bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core protocol dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->