### PR TITLE
ENG-590 Add OCF object type read helper

### DIFF
--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -246,7 +246,7 @@ function getOpenCapTableObjectReader<T extends OcfReadableObjectType>(
   const entityType = mapOcfObjectTypeToEntityType(String(objectType));
   if (entityType === null) {
     throw new OcpValidationError('objectType', `Unsupported OCF object_type: ${objectType}`, {
-      code: OcpErrorCodes.UNKNOWN_ENTITY_TYPE,
+      code: OcpErrorCodes.UNKNOWN_ENUM_VALUE,
       receivedValue: objectType,
     });
   }

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -126,10 +126,12 @@ import {
   classifyIssuerCapTables,
   ENTITY_OBJECT_TYPE_MAP,
   getCapTableState,
+  mapOcfObjectTypeToEntityType,
   type ArchiveCapTableParams,
   type ArchiveCapTableResult,
   type CapTableState,
   type IssuerCapTableClassification,
+  type OcfReadableObjectType,
 } from './functions/OpenCapTable/capTable';
 import { mergeCommandContext, type CommandObservabilityOptions, type OcpObservabilityOptions } from './observability';
 import type { CommandWithDisclosedContracts } from './types';
@@ -152,6 +154,7 @@ import type {
   OcfEquityCompensationTransferOutput,
   OcfIssuerAuthorizedSharesAdjustmentOutput,
   OcfIssuerOutput,
+  OcfOutputForObjectType,
   OcfStakeholderOutput,
   OcfStakeholderRelationshipChangeEventOutput,
   OcfStakeholderStatusChangeEventOutput,
@@ -231,6 +234,24 @@ function makeGenericEntityReader<T>(
       return toContractResult<T>(withObjectType(r.data, ENTITY_OBJECT_TYPE_MAP[entityType]), r.contractId);
     },
   };
+}
+
+type OpenCapTableObjectReaderKey = ReturnType<typeof mapOcfObjectTypeToEntityType> & keyof OpenCapTableMethods;
+type OpenCapTableObjectReaderMap = Pick<OpenCapTableMethods, OpenCapTableObjectReaderKey>;
+
+function getOpenCapTableObjectReader<T extends OcfReadableObjectType>(
+  readers: OpenCapTableObjectReaderMap,
+  objectType: T
+): EntityReader<OcfOutputForObjectType<T>> {
+  const entityType = mapOcfObjectTypeToEntityType(String(objectType));
+  if (entityType === null) {
+    throw new OcpValidationError('objectType', `Unsupported OCF object_type: ${objectType}`, {
+      code: OcpErrorCodes.UNKNOWN_ENTITY_TYPE,
+      receivedValue: objectType,
+    });
+  }
+
+  return readers[entityType as OpenCapTableObjectReaderKey] as EntityReader<OcfOutputForObjectType<T>>;
 }
 
 // ===== Context Manager =====
@@ -572,7 +593,7 @@ export class OcpClient {
     const genericEntity = <T>(entityType: Parameters<typeof getEntityAsOcf>[1]): EntityReader<T> =>
       makeGenericEntityReader<T>(client, entityType);
 
-    return {
+    const methods = {
       // ===== Objects =====
       issuer: {
         get: async (params) => getIssuerAsOcf(client, params),
@@ -891,6 +912,14 @@ export class OcpClient {
         update: (params: CapTableUpdateParams) => new CapTableBatch(this.withObservability(params), client),
         archive: async (params: ArchiveCapTableParams) => archiveCapTable(client, this.withObservability(params)),
       },
+    } satisfies Omit<OpenCapTableMethods, 'getByObjectType'>;
+
+    return {
+      getByObjectType: async ({ objectType, ...params }) => {
+        const reader = getOpenCapTableObjectReader(methods, objectType);
+        return reader.get(params);
+      },
+      ...methods,
     };
   }
 }
@@ -982,6 +1011,14 @@ function validateInjectedEnvironment(environment: OcpEnvironment | undefined, le
   }
 }
 
+/** Parameters for reading an OCF contract by its `object_type` and contract ID. */
+export interface GetByObjectTypeParams<
+  T extends OcfReadableObjectType = OcfReadableObjectType,
+> extends GetByContractIdParams {
+  /** OCF `object_type` discriminant, e.g. `STOCK_CLASS` or `TX_STOCK_ISSUANCE`. */
+  objectType: T;
+}
+
 /** Parameters for creating a batch cap table update */
 interface CapTableUpdateParams extends CommandObservabilityOptions {
   /** The contract ID of the CapTable to update */
@@ -1013,6 +1050,14 @@ interface EntityReader<T> {
  * an `object_type` discriminant for type-safe pattern matching.
  */
 interface OpenCapTableMethods {
+  /**
+   * Retrieve a contract by OCF `object_type` without manually switching over
+   * `OpenCapTable.<entity>.get()` reader namespaces.
+   */
+  getByObjectType: <T extends OcfReadableObjectType>(
+    params: GetByObjectTypeParams<T>
+  ) => Promise<ContractResult<OcfOutputForObjectType<T>>>;
+
   // Objects
   issuer: EntityReader<OcfIssuerOutput> & {
     /** Build a CreateIssuer command (for use with transaction batches) */

--- a/src/functions/OpenCapTable/capTable/batchTypes.ts
+++ b/src/functions/OpenCapTable/capTable/batchTypes.ts
@@ -580,6 +580,83 @@ export const ENTITY_REGISTRY = {
   },
 } as const satisfies Record<OcfEntityType, OcfEntityRegistryEntry>;
 
+/**
+ * Canonical OCF `object_type` to SDK entity reader mapping.
+ *
+ * PlanSecurity aliases intentionally resolve to the EquityCompensation object types in
+ * {@link ENTITY_REGISTRY}, so this map exposes the canonical ledger object types that
+ * have first-class read facades.
+ */
+export const OCF_OBJECT_TYPE_TO_ENTITY_TYPE = {
+  CE_STAKEHOLDER_RELATIONSHIP: 'stakeholderRelationshipChangeEvent',
+  CE_STAKEHOLDER_STATUS: 'stakeholderStatusChangeEvent',
+  DOCUMENT: 'document',
+  ISSUER: 'issuer',
+  STAKEHOLDER: 'stakeholder',
+  STOCK_CLASS: 'stockClass',
+  STOCK_LEGEND_TEMPLATE: 'stockLegendTemplate',
+  STOCK_PLAN: 'stockPlan',
+  TX_CONVERTIBLE_ACCEPTANCE: 'convertibleAcceptance',
+  TX_CONVERTIBLE_CANCELLATION: 'convertibleCancellation',
+  TX_CONVERTIBLE_CONVERSION: 'convertibleConversion',
+  TX_CONVERTIBLE_ISSUANCE: 'convertibleIssuance',
+  TX_CONVERTIBLE_RETRACTION: 'convertibleRetraction',
+  TX_CONVERTIBLE_TRANSFER: 'convertibleTransfer',
+  TX_EQUITY_COMPENSATION_ACCEPTANCE: 'equityCompensationAcceptance',
+  TX_EQUITY_COMPENSATION_CANCELLATION: 'equityCompensationCancellation',
+  TX_EQUITY_COMPENSATION_EXERCISE: 'equityCompensationExercise',
+  TX_EQUITY_COMPENSATION_ISSUANCE: 'equityCompensationIssuance',
+  TX_EQUITY_COMPENSATION_RELEASE: 'equityCompensationRelease',
+  TX_EQUITY_COMPENSATION_REPRICING: 'equityCompensationRepricing',
+  TX_EQUITY_COMPENSATION_RETRACTION: 'equityCompensationRetraction',
+  TX_EQUITY_COMPENSATION_TRANSFER: 'equityCompensationTransfer',
+  TX_ISSUER_AUTHORIZED_SHARES_ADJUSTMENT: 'issuerAuthorizedSharesAdjustment',
+  TX_STOCK_ACCEPTANCE: 'stockAcceptance',
+  TX_STOCK_CANCELLATION: 'stockCancellation',
+  TX_STOCK_CLASS_AUTHORIZED_SHARES_ADJUSTMENT: 'stockClassAuthorizedSharesAdjustment',
+  TX_STOCK_CLASS_CONVERSION_RATIO_ADJUSTMENT: 'stockClassConversionRatioAdjustment',
+  TX_STOCK_CLASS_SPLIT: 'stockClassSplit',
+  TX_STOCK_CONSOLIDATION: 'stockConsolidation',
+  TX_STOCK_CONVERSION: 'stockConversion',
+  TX_STOCK_ISSUANCE: 'stockIssuance',
+  TX_STOCK_PLAN_POOL_ADJUSTMENT: 'stockPlanPoolAdjustment',
+  TX_STOCK_PLAN_RETURN_TO_POOL: 'stockPlanReturnToPool',
+  TX_STOCK_REISSUANCE: 'stockReissuance',
+  TX_STOCK_REPURCHASE: 'stockRepurchase',
+  TX_STOCK_RETRACTION: 'stockRetraction',
+  TX_STOCK_TRANSFER: 'stockTransfer',
+  TX_VESTING_ACCELERATION: 'vestingAcceleration',
+  TX_VESTING_EVENT: 'vestingEvent',
+  TX_VESTING_START: 'vestingStart',
+  TX_WARRANT_ACCEPTANCE: 'warrantAcceptance',
+  TX_WARRANT_CANCELLATION: 'warrantCancellation',
+  TX_WARRANT_EXERCISE: 'warrantExercise',
+  TX_WARRANT_ISSUANCE: 'warrantIssuance',
+  TX_WARRANT_RETRACTION: 'warrantRetraction',
+  TX_WARRANT_TRANSFER: 'warrantTransfer',
+  VALUATION: 'valuation',
+  VESTING_TERMS: 'vestingTerms',
+} as const satisfies Record<string, OcfEntityType>;
+
+/** OCF object types that can be read through OpenCapTable entity readers. */
+export type OcfReadableObjectType = keyof typeof OCF_OBJECT_TYPE_TO_ENTITY_TYPE;
+
+/** SDK entity reader name for a given OCF object type. */
+export type OcfEntityTypeForObjectType<T extends OcfReadableObjectType> = (typeof OCF_OBJECT_TYPE_TO_ENTITY_TYPE)[T];
+
+export function mapOcfObjectTypeToEntityType<T extends OcfReadableObjectType>(
+  objectType: T
+): OcfEntityTypeForObjectType<T>;
+export function mapOcfObjectTypeToEntityType(objectType: string): OcfEntityType | null;
+export function mapOcfObjectTypeToEntityType(objectType: string): OcfEntityType | null {
+  return isOcfReadableObjectType(objectType) ? OCF_OBJECT_TYPE_TO_ENTITY_TYPE[objectType] : null;
+}
+
+/** Runtime guard for OCF object types supported by OpenCapTable readers. */
+export function isOcfReadableObjectType(objectType: string): objectType is OcfReadableObjectType {
+  return Object.prototype.hasOwnProperty.call(OCF_OBJECT_TYPE_TO_ENTITY_TYPE, objectType);
+}
+
 function entityRegistryEntries(): Array<[OcfEntityType, OcfEntityRegistryEntry]> {
   return Object.entries(ENTITY_REGISTRY) as Array<[OcfEntityType, OcfEntityRegistryEntry]>;
 }

--- a/src/types/output.ts
+++ b/src/types/output.ts
@@ -419,3 +419,9 @@ export type OcfObject =
   // Stakeholder Events
   | OcfStakeholderRelationshipChangeEventOutput
   | OcfStakeholderStatusChangeEventOutput;
+
+/** Entity output type for a specific OCF `object_type` discriminant. */
+export type OcfOutputForObjectType<T extends OcfObject['object_type']> = Extract<
+  OcfObject,
+  { readonly object_type: T }
+>;

--- a/test/client/OcpClient.test.ts
+++ b/test/client/OcpClient.test.ts
@@ -1,5 +1,6 @@
 import { Canton, type ClientConfig } from '@fairmint/canton-node-sdk';
 import { Fairmint } from '@fairmint/open-captable-protocol-daml-js';
+import { OcpErrorCodes } from '../../src/errors';
 import * as openCapTableCapTable from '../../src/functions/OpenCapTable/capTable';
 import {
   ENTITY_REGISTRY,
@@ -426,6 +427,12 @@ describe('OcpClient OpenCapTable entity facade', () => {
         contractId: 'unknown-cid',
       })
     ).rejects.toThrow('Unsupported OCF object_type: UNKNOWN_OBJECT_TYPE');
+    await expect(
+      ocp.OpenCapTable.getByObjectType({
+        objectType: 'UNKNOWN_OBJECT_TYPE' as OcfReadableObjectType,
+        contractId: 'unknown-cid',
+      })
+    ).rejects.toMatchObject({ code: OcpErrorCodes.UNKNOWN_ENUM_VALUE });
   });
 
   it('preserves concrete output inference for literal object types', async () => {

--- a/test/client/OcpClient.test.ts
+++ b/test/client/OcpClient.test.ts
@@ -2,10 +2,17 @@ import { Canton, type ClientConfig } from '@fairmint/canton-node-sdk';
 import { Fairmint } from '@fairmint/open-captable-protocol-daml-js';
 import * as openCapTableCapTable from '../../src/functions/OpenCapTable/capTable';
 import {
+  ENTITY_REGISTRY,
+  OCF_OBJECT_TYPE_TO_ENTITY_TYPE,
+  mapOcfObjectTypeToEntityType,
+  type OcfReadableObjectType,
+} from '../../src/functions/OpenCapTable/capTable';
+import {
   authorizeIssuer,
   type AuthorizeIssuerResult,
 } from '../../src/functions/OpenCapTable/issuerAuthorization/authorizeIssuer';
 import { OcpClient } from '../../src/OcpClient';
+import type { ContractResult, OcfOutputForObjectType } from '../../src/types';
 import { createLedgerAndValidatorClients, createLedgerJsonApiClient } from '../utils/cantonNodeSdkCompat';
 
 jest.mock('../../src/functions/OpenCapTable/issuerAuthorization/authorizeIssuer', () => ({
@@ -367,6 +374,94 @@ describe('OcpClient OpenCapTable.capTable facade', () => {
 });
 
 describe('OcpClient OpenCapTable entity facade', () => {
+  type ObjectReaderEntityType = (typeof OCF_OBJECT_TYPE_TO_ENTITY_TYPE)[OcfReadableObjectType];
+  const objectTypeReaderEntries = Object.entries(OCF_OBJECT_TYPE_TO_ENTITY_TYPE) as Array<
+    [OcfReadableObjectType, ObjectReaderEntityType]
+  >;
+
+  it('exports one canonical OCF object_type mapping for each readable registry entry', () => {
+    const expected = Object.fromEntries(
+      Object.entries(ENTITY_REGISTRY)
+        .filter(([entityType]) => !entityType.startsWith('planSecurity'))
+        .map(([entityType, entry]) => [entry.objectType, entityType])
+    );
+
+    expect(OCF_OBJECT_TYPE_TO_ENTITY_TYPE).toEqual(expected);
+  });
+
+  it.each(objectTypeReaderEntries)('maps %s to %s', (objectType, entityType) => {
+    expect(mapOcfObjectTypeToEntityType(objectType)).toBe(entityType);
+  });
+
+  it.each(objectTypeReaderEntries)('dispatches getByObjectType(%s) through %s.get', async (objectType, entityType) => {
+    const ledger = createLedgerJsonApiClient({ network: 'devnet' });
+    const ocp = new OcpClient({ ledger });
+    const expected = {
+      contractId: `cid-${objectType}`,
+      data: { object_type: objectType },
+    };
+    const getMock = jest.fn().mockResolvedValue(expected);
+    (ocp.OpenCapTable[entityType] as { get: typeof getMock }).get = getMock;
+
+    const result = await ocp.OpenCapTable.getByObjectType({
+      objectType,
+      contractId: `cid-${objectType}`,
+      readAs: ['issuer::party-1'],
+    });
+
+    expect(result).toBe(expected);
+    expect(getMock).toHaveBeenCalledWith({
+      contractId: `cid-${objectType}`,
+      readAs: ['issuer::party-1'],
+    });
+  });
+
+  it('rejects unsupported runtime object types', async () => {
+    const ledger = createLedgerJsonApiClient({ network: 'devnet' });
+    const ocp = new OcpClient({ ledger });
+
+    await expect(
+      ocp.OpenCapTable.getByObjectType({
+        objectType: 'UNKNOWN_OBJECT_TYPE' as OcfReadableObjectType,
+        contractId: 'unknown-cid',
+      })
+    ).rejects.toThrow('Unsupported OCF object_type: UNKNOWN_OBJECT_TYPE');
+  });
+
+  it('preserves concrete output inference for literal object types', async () => {
+    const ledger = createLedgerJsonApiClient({ network: 'devnet' });
+    const ocp = new OcpClient({ ledger });
+    const expected: ContractResult<OcfOutputForObjectType<'STOCK_CLASS'>> = {
+      contractId: 'stock-class-cid-1',
+      data: {
+        object_type: 'STOCK_CLASS',
+        id: 'stock-class-1',
+        class_type: 'COMMON',
+        default_id_prefix: 'CS-',
+        initial_shares_authorized: '1000',
+        name: 'Common Stock',
+        seniority: '1',
+        board_approval_date: '2025-01-01',
+        votes_per_share: '1',
+        par_value: { amount: '0.00001', currency: 'USD' },
+        price_per_share: { amount: '1', currency: 'USD' },
+        comments: [],
+      },
+    };
+    const getMock = jest.fn().mockResolvedValue(expected);
+    (ocp.OpenCapTable.stockClass as { get: typeof getMock }).get = getMock;
+
+    const result = await ocp.OpenCapTable.getByObjectType({
+      objectType: 'STOCK_CLASS',
+      contractId: 'stock-class-cid-1',
+    });
+    const objectType: 'STOCK_CLASS' = result.data.object_type;
+    const { id }: { id: string } = result.data;
+
+    expect(objectType).toBe('STOCK_CLASS');
+    expect(id).toBe('stock-class-1');
+  });
+
   it('forwards issuer.get readAs through the OcpClient facade', async () => {
     const issuerTemplateId = Fairmint.OpenCapTable.OCF.Issuer.Issuer.templateId;
     const ledger = {


### PR DESCRIPTION
## Summary
- add a canonical `OCF_OBJECT_TYPE_TO_ENTITY_TYPE` map plus runtime/type helpers for readable OCF object types
- add `OpenCapTable.getByObjectType()` so callers can read by OCF `object_type` and contract id without local switch/cast logic
- add typed output inference and exhaustive dispatch coverage for all canonical registry-backed readable object types
- document the helper in the GitHub wiki; wiki commit `eb924b5` is already pushed

## Validation
- `npm run -s test:ci`
- `npm run -s lint`
- `npm run -s format`
- `git diff --check`

## Duplicate-effort check
No existing ENG-590 PR, branch, local worktree, or active Codex session was found. Existing open PRs were dependency/ENG-520/ENG-476 work and did not overlap.

Linear: ENG-590

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path API addition with delegation to existing entity readers; no ledger write or auth changes.
> 
> **Overview**
> Adds **`OpenCapTable.getByObjectType()`** so callers can load a contract by OCF **`object_type`** and contract id instead of picking the right `OpenCapTable.<entity>.get()` namespace or maintaining their own switch.
> 
> The implementation introduces a canonical **`OCF_OBJECT_TYPE_TO_ENTITY_TYPE`** map (canonical ledger types only—**PlanSecurity** aliases stay on equity-compensation readers), plus **`mapOcfObjectTypeToEntityType`**, **`isOcfReadableObjectType`**, and **`OcfReadableObjectType`**. Unsupported runtime types throw **`OcpValidationError`** with **`UNKNOWN_ENUM_VALUE`**. **`OcfOutputForObjectType<T>`** ties literal `objectType` values to the matching output shape on **`ContractResult`**.
> 
> Tests assert the map matches **`ENTITY_REGISTRY`** (minus plan-security keys), exhaustive dispatch for every readable type, error handling, and TypeScript inference for a sample type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b540d4b28fc6ffbf7053f0169a26c61980c6a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `getByObjectType` method to the OpenCapTable API, enabling type-safe queries of ledger objects by type discriminator with automatic response type inference and strong typing.
  * Implemented runtime validation to detect and report unsupported object types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->