### PR TITLE
[codex] Bump Canton node SDK peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "15.3.5",
     "@eslint/eslintrc": "3.3.5",
-    "@fairmint/canton-node-sdk": "0.0.208",
+    "@fairmint/canton-node-sdk": "0.0.209",
     "@fairmint/open-captable-protocol-daml-js": "0.3.3",
     "@types/jest": "30.0.0",
     "@types/jsonwebtoken": "9.0.10",
@@ -75,7 +75,7 @@
     "typescript": "6.0.3"
   },
   "peerDependencies": {
-    "@fairmint/canton-node-sdk": ">=0.0.208 <0.1.0",
+    "@fairmint/canton-node-sdk": ">=0.0.209 <0.1.0",
     "@fairmint/open-captable-protocol-daml-js": ">=0.3.3 <0.4.0"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Bump the OCP Canton SDK dev dependency on `@fairmint/canton-node-sdk` to `0.0.209`.
- Raise the node SDK peer floor to `>=0.0.209 <0.1.0`.

## Validation
- `npm run test:ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bump only; no application code changes, though consumers on 0.0.208 will need to upgrade their peer install.
> 
> **Overview**
> Bumps **`@fairmint/canton-node-sdk`** from **0.0.208** to **0.0.209** for local/dev installs and raises the **peer dependency** minimum to **`>=0.0.209 <0.1.0`**, so consumers must use at least that SDK patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c666fe77e2643f0f0a77a6862341be632969e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->