### PR TITLE
chore: bump Fairmint package consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "15.3.5",
     "@eslint/eslintrc": "3.3.5",
-    "@fairmint/canton-node-sdk": "0.0.209",
-    "@fairmint/open-captable-protocol-daml-js": "0.3.3",
+    "@fairmint/canton-node-sdk": "0.0.223",
+    "@fairmint/open-captable-protocol-daml-js": "0.3.7",
     "@types/jest": "30.0.0",
     "@types/jsonwebtoken": "9.0.10",
     "@types/node": "25.6.0",
@@ -75,8 +75,8 @@
     "typescript": "6.0.3"
   },
   "peerDependencies": {
-    "@fairmint/canton-node-sdk": ">=0.0.209 <0.1.0",
-    "@fairmint/open-captable-protocol-daml-js": ">=0.3.3 <0.4.0"
+    "@fairmint/canton-node-sdk": ">=0.0.223 <0.1.0",
+    "@fairmint/open-captable-protocol-daml-js": ">=0.3.7 <0.4.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- bump @fairmint/canton-node-sdk dev pin and peer lower bound to 0.0.223
- bump @fairmint/open-captable-protocol-daml-js dev pin and peer lower bound to 0.3.7

## Validation
- npm view @fairmint/canton-node-sdk@0.0.223 version
- npm view @fairmint/open-captable-protocol-daml-js@0.3.7 version
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bumps in package.json; risk is limited to potential breaking changes in the bumped Fairmint packages at install/runtime.
> 
> **Overview**
> Updates **Fairmint consumer package versions** in `package.json` only—no application code changes.
> 
> **`@fairmint/canton-node-sdk`** moves from **0.0.209** to **0.0.223** in `devDependencies`, and the **`peerDependencies`** minimum is raised to **`>=0.0.223 <0.1.0`** so installs align with the new SDK.
> 
> **`@fairmint/open-captable-protocol-daml-js`** moves from **0.3.3** to **0.3.7** in `devDependencies`, with the peer floor updated to **`>=0.3.7 <0.4.0`**.
> 
> Downstream apps must satisfy the new peer ranges when they upgrade this SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8815b31a2e5e5d78ad06cc2b0520b897ae309bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->