### PR TITLE
ci: cache packaged LocalNet assets

### DIFF
--- a/.github/workflows/test-ocp-quickstart.yml
+++ b/.github/workflows/test-ocp-quickstart.yml
@@ -71,6 +71,14 @@ jobs:
       - name: Build Package
         run: npm run build
 
+      - name: Restore LocalNet asset cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/fairmint/canton-localnet
+          key: canton-localnet-${{ runner.os }}-${{ hashFiles('package.json') }}
+          restore-keys: |
+            canton-localnet-${{ runner.os }}-
+
       - name: Start LocalNet
         run: |
           npm run localnet:start


### PR DESCRIPTION
## What changed
- Restore `~/.cache/fairmint/canton-localnet` before the packaged LocalNet startup workflow.
- Key the cache from `package.json`, which carries the packaged LocalNet quickstart ref.

## Baseline
Latest comparable successful quickstart run before this change: run 28979532480.
- `Start LocalNet`: 4m49.
- `cn-quickstart setup` path, including Gradle bootstrap: about 1m46 before container startup.

## Expected measurement
The first run may populate the cache. A warm run should reuse the cached `cn-quickstart` checkout and `.env.local`, avoiding the setup/Gradle path before container startup.

## Validation
- `git diff --check`
- YAML parse for `.github/workflows/test-ocp-quickstart.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only caching with no application or security impact; cache key invalidates when `package.json` changes.
> 
> **Overview**
> Adds a **Restore LocalNet asset cache** step to the OCP CN-Quickstart workflow, placed after `npm run build` and before **Start LocalNet**.
> 
> The step uses `actions/cache@v5` for `~/.cache/fairmint/canton-localnet`, with a primary key tied to `package.json` (packaged LocalNet quickstart ref) and OS-scoped restore keys. Warm runs should skip repeated `cn-quickstart` setup/Gradle work before containers start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 343945b79146fcef7ea708754ee402525249d136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->