### PR TITLE
Use TypeScript 7 compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc && npm run copy-ocf-schemas",
+    "build": "npm run tsc7 && npm run copy-ocf-schemas",
     "clean": "rm -rf dist",
     "copy-ocf-schemas": "ts-node --project tsconfig.tests.json scripts/copy-ocf-schemas.ts",
-    "dev": "tsc --watch",
+    "dev": "npm run tsc7 -- --watch",
     "fix": "npm run lint:fix && npm run format:fix",
     "flatten-schemas": "ts-node --project tsconfig.tests.json scripts/flatten-ocf-schemas.ts",
     "format": "prettier --check .",
@@ -42,7 +42,8 @@
     "test:integration": "npm run -s typecheck && jest -c jest.integration.config.js --passWithNoTests",
     "test:integration:ci": "npm run -s typecheck && jest -c jest.integration.config.js --runInBand",
     "test:watch": "jest --watch",
-    "typecheck": "tsc -p tsconfig.tests.json --noEmit"
+    "typecheck": "npm run tsc7 -- -p tsconfig.tests.json --noEmit",
+    "tsc7": "node node_modules/typescript-7/bin/tsc"
   },
   "config": {
     "localnet_quickstart_ref": "5c90cf4d0eb934712fd8c269b56e6272b605ccad"
@@ -77,7 +78,8 @@
     "prettier-plugin-packagejson": "3.0.2",
     "ts-jest": "29.4.9",
     "ts-node": "10.9.2",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "typescript-7": "npm:typescript@7.0.2"
   },
   "peerDependencies": {
     "@fairmint/canton-node-sdk": ">=0.0.223 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "test:integration": "npm run -s typecheck && jest -c jest.integration.config.js --passWithNoTests",
     "test:integration:ci": "npm run -s typecheck && jest -c jest.integration.config.js --runInBand",
     "test:watch": "jest --watch",
-    "typecheck": "npm run tsc7 -- -p tsconfig.tests.json --noEmit",
-    "tsc7": "node node_modules/typescript-7/bin/tsc"
+    "tsc7": "node node_modules/typescript-7/bin/tsc",
+    "typecheck": "npm run tsc7 -- -p tsconfig.tests.json --noEmit"
   },
   "config": {
     "localnet_quickstart_ref": "5c90cf4d0eb934712fd8c269b56e6272b605ccad"

--- a/test/batch/CapTableBatch.test.ts
+++ b/test/batch/CapTableBatch.test.ts
@@ -1,6 +1,6 @@
 /** Unit tests for CapTableBatch fluent builder. */
 
-import { CapTable } from '@fairmint/open-captable-protocol-daml-js/lib/Fairmint/OpenCapTable/CapTable/module';
+import { CapTable } from '@fairmint/open-captable-protocol-daml-js/lib/Fairmint/OpenCapTable/CapTable/module.js';
 import { OcpErrorCodes, OcpValidationError } from '../../src/errors';
 import { buildUpdateCapTableCommand, CapTableBatch, ENTITY_TAG_MAP } from '../../src/functions/OpenCapTable/capTable';
 import type {

--- a/test/capTable/archiveCapTable.test.ts
+++ b/test/capTable/archiveCapTable.test.ts
@@ -6,7 +6,7 @@
  */
 
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
-import { CapTable } from '@fairmint/open-captable-protocol-daml-js/lib/Fairmint/OpenCapTable/CapTable/module';
+import { CapTable } from '@fairmint/open-captable-protocol-daml-js/lib/Fairmint/OpenCapTable/CapTable/module.js';
 import { OcpValidationError } from '../../src/errors';
 import {
   archiveCapTable,

--- a/test/capTable/archiveFullCapTable.test.ts
+++ b/test/capTable/archiveFullCapTable.test.ts
@@ -1,6 +1,6 @@
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
 import { OCP_TEMPLATES } from '@fairmint/open-captable-protocol-daml-js';
-import { CapTable } from '@fairmint/open-captable-protocol-daml-js/lib/Fairmint/OpenCapTable/CapTable/module';
+import { CapTable } from '@fairmint/open-captable-protocol-daml-js/lib/Fairmint/OpenCapTable/CapTable/module.js';
 import {
   archiveFullCapTable,
   getSystemOperatorPartyId,

--- a/test/capTable/getCapTableState.test.ts
+++ b/test/capTable/getCapTableState.test.ts
@@ -8,7 +8,7 @@
 
 import type { LedgerJsonApiClient } from '@fairmint/canton-node-sdk';
 import { OCP_TEMPLATES } from '@fairmint/open-captable-protocol-daml-js';
-import { CapTable } from '@fairmint/open-captable-protocol-daml-js/lib/Fairmint/OpenCapTable/CapTable/module';
+import { CapTable } from '@fairmint/open-captable-protocol-daml-js/lib/Fairmint/OpenCapTable/CapTable/module.js';
 import { OcpErrorCodes } from '../../src/errors';
 import { classifyIssuerCapTables, getCapTableState } from '../../src/functions/OpenCapTable/capTable';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "declarationMap": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node",
     "ignoreDeprecations": "6.0",
     "allowSyntheticDefaultImports": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
## Summary

- Add a `typescript-7` alias pinned to `npm:typescript@7.0.2`.
- Route build/dev/typecheck scripts through TS7 while keeping the existing `typescript` package for Jest/ESLint/ts-node peer compatibility.
- Remove the TS7-removed `moduleResolution: "node"` setting and add `.js` to package-exported deep imports in tests.

## CI Time

Measured from GitHub Actions check-run durations by summing the latest matching CI/build/test jobs before and after this branch. Deploy previews, security scans, and AI review jobs are excluded.

- Before: `9m 56s` total across 2 comparable CI job(s).
- After: `9m 34s` total across 2 comparable CI job(s).
- Time saved: `22s` (`3.7%` faster).
- Job timings: `build-and-test` 1m 36s -> 1m 26s, `test-ocp-quickstart` 8m 20s -> 8m 8s.
## Validation

- `npm install --ignore-scripts --package-lock=false`
- `npm run typecheck`
