### PR TITLE
Enforce exact optional properties across the SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,11 +50,10 @@
     "test:coverage": "jest --coverage --passWithNoTests",
     "test:declarations": "ts-node --project tsconfig.tests.json scripts/check-declarations.ts && tsc -p tsconfig.declaration-tests.json --noEmit && npm run -s test:exact-public-config",
     "test:exact-public-config": "tsc -p tsconfig.exact-public-config-tests.json --noEmit",
-    "test:exact-source": "tsc -p tsconfig.exact-source.json --noEmit",
     "test:integration": "npm run -s typecheck && jest -c jest.integration.config.js --passWithNoTests",
     "test:integration:ci": "npm run -s typecheck && jest -c jest.integration.config.js --runInBand",
     "test:watch": "jest --watch",
-    "typecheck": "tsc -p tsconfig.tests.json --noEmit && npm run -s test:exact-source"
+    "typecheck": "tsc -p tsconfig.tests.json --noEmit"
   },
   "config": {
     "localnet_quickstart_ref": "5c90cf4d0eb934712fd8c269b56e6272b605ccad"

--- a/src/functions/OpenCapTable/shared/conversionMechanisms.ts
+++ b/src/functions/OpenCapTable/shared/conversionMechanisms.ts
@@ -617,13 +617,8 @@ export function warrantMechanismToDaml(mechanism: WarrantConversionMechanism): D
           description: mechanism.description,
           discount: mechanism.discount,
           discount_percentage:
-            'discount_percentage' in mechanism && mechanism.discount_percentage !== undefined
-              ? normalizeNumericString(mechanism.discount_percentage)
-              : null,
-          discount_amount:
-            'discount_amount' in mechanism && mechanism.discount_amount
-              ? monetaryToDaml(mechanism.discount_amount)
-              : null,
+            mechanism.discount_percentage !== undefined ? normalizeNumericString(mechanism.discount_percentage) : null,
+          discount_amount: mechanism.discount_amount !== undefined ? monetaryToDaml(mechanism.discount_amount) : null,
         },
       };
     default:

--- a/test/capTable/archiveFullCapTable.test.ts
+++ b/test/capTable/archiveFullCapTable.test.ts
@@ -42,14 +42,16 @@ function mockActiveContractsForCapTableState(
   responses: { current?: unknown[] }
 ): void {
   const current = responses.current ?? [];
-  mockClient.getActiveContracts.mockImplementation(async (req: { templateIds?: string[] }) => {
-    await Promise.resolve();
-    const ids = req.templateIds;
-    if (isCurrentTemplateQuery(ids)) {
-      return current as never;
+  mockClient.getActiveContracts.mockImplementation(
+    async (req: Parameters<LedgerJsonApiClient['getActiveContracts']>[0]) => {
+      await Promise.resolve();
+      const ids = req.templateIds;
+      if (isCurrentTemplateQuery(ids)) {
+        return current as never;
+      }
+      throw new Error(`Unexpected getActiveContracts templateIds in test: ${JSON.stringify(ids)}`);
     }
-    throw new Error(`Unexpected getActiveContracts templateIds in test: ${JSON.stringify(ids)}`);
-  });
+  );
 }
 
 interface TestIssuerData {

--- a/test/capTable/getCapTableState.test.ts
+++ b/test/capTable/getCapTableState.test.ts
@@ -41,14 +41,16 @@ function mockActiveContractsForCapTableState(
   responses: { current?: unknown[] }
 ): void {
   const current = responses.current ?? [];
-  mockClient.getActiveContracts.mockImplementation(async (req: { templateIds?: string[] }) => {
-    await Promise.resolve();
-    const ids = req.templateIds;
-    if (isCurrentTemplateQuery(ids)) {
-      return current as never;
+  mockClient.getActiveContracts.mockImplementation(
+    async (req: Parameters<LedgerJsonApiClient['getActiveContracts']>[0]) => {
+      await Promise.resolve();
+      const ids = req.templateIds;
+      if (isCurrentTemplateQuery(ids)) {
+        return current as never;
+      }
+      throw new Error(`Unexpected getActiveContracts templateIds in test: ${JSON.stringify(ids)}`);
     }
-    throw new Error(`Unexpected getActiveContracts templateIds in test: ${JSON.stringify(ids)}`);
-  });
+  );
 }
 
 /**

--- a/test/client/OcpClient.test.ts
+++ b/test/client/OcpClient.test.ts
@@ -296,7 +296,7 @@ describe('OcpClient OpenCapTable.issuerAuthorization.authorize', () => {
     expect(mockedAuthorizeIssuer).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps client-level observability defaults when per-call fields are undefined', async () => {
+  it('keeps client-level observability defaults when per-call fields are omitted', async () => {
     const ledger = createLedgerJsonApiClient(config);
     const logger = {
       debug: jest.fn(),
@@ -318,9 +318,6 @@ describe('OcpClient OpenCapTable.issuerAuthorization.authorize', () => {
 
     await ocp.OpenCapTable.issuerAuthorization.authorize({
       issuer: 'issuer::party',
-      logger: undefined,
-      metrics: undefined,
-      defaultContext: undefined,
       context: { commandId: 'command-call' },
     });
 

--- a/test/client/OcpContextManager.test.ts
+++ b/test/client/OcpContextManager.test.ts
@@ -77,11 +77,9 @@ describe('OcpContextManager', () => {
       expect(contextManager.issuerParty).toBeNull();
     });
 
-    it('should not change values when undefined is passed', () => {
+    it('should not change omitted values', () => {
       contextManager.setIssuerParty('issuer::party-123');
-      contextManager.setAll({
-        issuerParty: undefined,
-      });
+      contextManager.setAll({});
 
       expect(contextManager.issuerParty).toBe('issuer::party-123');
     });

--- a/test/integration/entities/acceptanceTypes.integration.test.ts
+++ b/test/integration/entities/acceptanceTypes.integration.test.ts
@@ -33,6 +33,7 @@ import {
   setupStockSecurity,
   setupTestIssuer,
   setupWarrantSecurity,
+  withCapTableContractDetails,
 } from '../utils';
 
 /**
@@ -141,7 +142,7 @@ createIntegrationTestSuite('Acceptance Type operations', (getContext) => {
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: stockSecurity.capTableContractId,
-      capTableContractDetails: updatedCapTableDetails,
+      ...withCapTableContractDetails(updatedCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 
@@ -189,7 +190,7 @@ createIntegrationTestSuite('Acceptance Type operations', (getContext) => {
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: warrantSecurity.capTableContractId,
-      capTableContractDetails: updatedCapTableDetails,
+      ...withCapTableContractDetails(updatedCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 
@@ -239,7 +240,7 @@ createIntegrationTestSuite('Acceptance Type operations', (getContext) => {
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: convertibleSecurity.capTableContractId,
-      capTableContractDetails: updatedCapTableDetails,
+      ...withCapTableContractDetails(updatedCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 
@@ -287,7 +288,7 @@ createIntegrationTestSuite('Acceptance Type operations', (getContext) => {
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: eqCompSecurity.capTableContractId,
-      capTableContractDetails: updatedCapTableDetails,
+      ...withCapTableContractDetails(updatedCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 
@@ -336,7 +337,7 @@ createIntegrationTestSuite('Acceptance Type operations', (getContext) => {
     const warrantSecurity = await setupWarrantSecurity(ctx.ocp, {
       issuerContractId: stockSecurity.capTableContractId,
       issuerParty: ctx.issuerParty,
-      capTableContractDetails: currentCapTableDetails,
+      ...withCapTableContractDetails(currentCapTableDetails),
     });
 
     events = await ctx.ocp.ledger.getEventsByContractId({ contractId: warrantSecurity.capTableContractId });
@@ -353,7 +354,7 @@ createIntegrationTestSuite('Acceptance Type operations', (getContext) => {
     const convertibleSecurity = await setupConvertibleSecurity(ctx.ocp, {
       issuerContractId: warrantSecurity.capTableContractId,
       issuerParty: ctx.issuerParty,
-      capTableContractDetails: currentCapTableDetails,
+      ...withCapTableContractDetails(currentCapTableDetails),
     });
 
     events = await ctx.ocp.ledger.getEventsByContractId({ contractId: convertibleSecurity.capTableContractId });
@@ -370,7 +371,7 @@ createIntegrationTestSuite('Acceptance Type operations', (getContext) => {
     const eqCompSecurity = await setupEquityCompensationSecurity(ctx.ocp, {
       issuerContractId: convertibleSecurity.capTableContractId,
       issuerParty: ctx.issuerParty,
-      capTableContractDetails: currentCapTableDetails,
+      ...withCapTableContractDetails(currentCapTableDetails),
     });
 
     events = await ctx.ocp.ledger.getEventsByContractId({ contractId: eqCompSecurity.capTableContractId });
@@ -402,7 +403,7 @@ createIntegrationTestSuite('Acceptance Type operations', (getContext) => {
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: eqCompSecurity.capTableContractId,
-      capTableContractDetails: finalCapTableDetails,
+      ...withCapTableContractDetails(finalCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 
@@ -459,7 +460,7 @@ createIntegrationTestSuite('Acceptance Type operations', (getContext) => {
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: stockSecurity.capTableContractId,
-      capTableContractDetails: updatedCapTableDetails,
+      ...withCapTableContractDetails(updatedCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 
@@ -512,7 +513,7 @@ createIntegrationTestSuite('Acceptance Type operations', (getContext) => {
     // Create the acceptance first
     const createBatch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: stockSecurity.capTableContractId,
-      capTableContractDetails: currentCapTableDetails,
+      ...withCapTableContractDetails(currentCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 
@@ -594,7 +595,7 @@ createIntegrationTestSuite('Acceptance Type operations', (getContext) => {
     // Create the acceptance first
     const createBatch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: stockSecurity.capTableContractId,
-      capTableContractDetails: currentCapTableDetails,
+      ...withCapTableContractDetails(currentCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 

--- a/test/integration/entities/stockClassAdjustments.integration.test.ts
+++ b/test/integration/entities/stockClassAdjustments.integration.test.ts
@@ -27,6 +27,7 @@ import {
   requireCreatedEventBlob,
   setupStockSecurity,
   setupTestIssuer,
+  withCapTableContractDetails,
 } from '../utils';
 
 createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
@@ -178,7 +179,7 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
     const stockSecurity2 = await setupStockSecurity(ctx.ocp, {
       issuerContractId: stockSecurity1.capTableContractId,
       issuerParty: ctx.issuerParty,
-      capTableContractDetails: currentCapTableDetails,
+      ...withCapTableContractDetails(currentCapTableDetails),
     });
 
     events = await ctx.ocp.ledger.getEventsByContractId({ contractId: stockSecurity2.capTableContractId });
@@ -194,7 +195,7 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
     const stockSecurity3 = await setupStockSecurity(ctx.ocp, {
       issuerContractId: stockSecurity2.capTableContractId,
       issuerParty: ctx.issuerParty,
-      capTableContractDetails: currentCapTableDetails,
+      ...withCapTableContractDetails(currentCapTableDetails),
     });
 
     events = await ctx.ocp.ledger.getEventsByContractId({ contractId: stockSecurity3.capTableContractId });
@@ -212,7 +213,7 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: stockSecurity3.capTableContractId,
-      capTableContractDetails: finalCapTableDetails,
+      ...withCapTableContractDetails(finalCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 
@@ -269,7 +270,7 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: stockSecurity.capTableContractId,
-      capTableContractDetails: updatedCapTableDetails,
+      ...withCapTableContractDetails(updatedCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 
@@ -325,7 +326,7 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
     const stockSecurity2 = await setupStockSecurity(ctx.ocp, {
       issuerContractId: stockSecurity1.capTableContractId,
       issuerParty: ctx.issuerParty,
-      capTableContractDetails: currentCapTableDetails,
+      ...withCapTableContractDetails(currentCapTableDetails),
     });
 
     events = await ctx.ocp.ledger.getEventsByContractId({ contractId: stockSecurity2.capTableContractId });
@@ -341,7 +342,7 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
     const stockSecurity3 = await setupStockSecurity(ctx.ocp, {
       issuerContractId: stockSecurity2.capTableContractId,
       issuerParty: ctx.issuerParty,
-      capTableContractDetails: currentCapTableDetails,
+      ...withCapTableContractDetails(currentCapTableDetails),
     });
 
     events = await ctx.ocp.ledger.getEventsByContractId({ contractId: stockSecurity3.capTableContractId });
@@ -356,7 +357,7 @@ createIntegrationTestSuite('Stock Class Adjustments', (getContext) => {
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: stockSecurity3.capTableContractId,
-      capTableContractDetails: finalCapTableDetails,
+      ...withCapTableContractDetails(finalCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 

--- a/test/integration/entities/transferTypes.integration.test.ts
+++ b/test/integration/entities/transferTypes.integration.test.ts
@@ -34,6 +34,7 @@ import {
   setupStockSecurity,
   setupTestIssuer,
   setupWarrantSecurity,
+  withCapTableContractDetails,
 } from '../utils';
 
 /** Extract a contract ID from a transaction tree response. */
@@ -107,7 +108,7 @@ createIntegrationTestSuite('Transfer Type operations', (getContext) => {
     const cmd = buildUpdateCapTableCommand(
       {
         capTableContractId: stockSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
       },
       { creates: [{ type: 'stockTransfer', data: transferData }] }
     );
@@ -185,7 +186,7 @@ createIntegrationTestSuite('Transfer Type operations', (getContext) => {
     const cmd = buildUpdateCapTableCommand(
       {
         capTableContractId: convertibleSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
       },
       { creates: [{ type: 'convertibleTransfer', data: transferData }] }
     );
@@ -258,7 +259,7 @@ createIntegrationTestSuite('Transfer Type operations', (getContext) => {
     const cmd = buildUpdateCapTableCommand(
       {
         capTableContractId: eqCompSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
       },
       { creates: [{ type: 'equityCompensationTransfer', data: transferData }] }
     );
@@ -330,7 +331,7 @@ createIntegrationTestSuite('Transfer Type operations', (getContext) => {
     const cmd = buildUpdateCapTableCommand(
       {
         capTableContractId: warrantSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
       },
       { creates: [{ type: 'warrantTransfer', data: transferData }] }
     );

--- a/test/integration/entities/valuationVesting.integration.test.ts
+++ b/test/integration/entities/valuationVesting.integration.test.ts
@@ -29,6 +29,7 @@ import {
   requireCreatedEventBlob,
   setupStockSecurity,
   setupTestIssuer,
+  withCapTableContractDetails,
 } from '../utils';
 
 function extractContractIdString(cid: { value: unknown }): string {
@@ -193,7 +194,7 @@ createIntegrationTestSuite('Valuation and Vesting types via batch API', (getCont
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: stockSecurity.capTableContractId,
-      capTableContractDetails: updatedCapTableDetails,
+      ...withCapTableContractDetails(updatedCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 
@@ -254,7 +255,7 @@ createIntegrationTestSuite('Valuation and Vesting types via batch API', (getCont
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: stockSecurity.capTableContractId,
-      capTableContractDetails: updatedCapTableDetails,
+      ...withCapTableContractDetails(updatedCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 
@@ -314,7 +315,7 @@ createIntegrationTestSuite('Valuation and Vesting types via batch API', (getCont
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: stockSecurity.capTableContractId,
-      capTableContractDetails: updatedCapTableDetails,
+      ...withCapTableContractDetails(updatedCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 
@@ -365,7 +366,7 @@ createIntegrationTestSuite('Valuation and Vesting types via batch API', (getCont
     const stockSecurity2 = await setupStockSecurity(ctx.ocp, {
       issuerContractId: stockSecurity1.capTableContractId,
       issuerParty: ctx.issuerParty,
-      capTableContractDetails: currentCapTableDetails,
+      ...withCapTableContractDetails(currentCapTableDetails),
     });
 
     events = await ctx.ocp.ledger.getEventsByContractId({ contractId: stockSecurity2.capTableContractId });
@@ -380,7 +381,7 @@ createIntegrationTestSuite('Valuation and Vesting types via batch API', (getCont
 
     const batch = ctx.ocp.OpenCapTable.capTable.update({
       capTableContractId: stockSecurity2.capTableContractId,
-      capTableContractDetails: finalCapTableDetails,
+      ...withCapTableContractDetails(finalCapTableDetails),
       actAs: [ctx.issuerParty],
     });
 

--- a/test/integration/production/productionDataRoundtrip.integration.test.ts
+++ b/test/integration/production/productionDataRoundtrip.integration.test.ts
@@ -37,6 +37,7 @@ import {
   setupTestIssuer,
   setupTestStakeholder,
   setupWarrantSecurity,
+  withCapTableContractDetails,
 } from '../utils';
 
 /**
@@ -120,7 +121,7 @@ async function createStockPlanPrerequisite(
   }
 ) {
   const stockPlanData = createTestStockPlanData({
-    id: params.stockPlanId,
+    ...(params.stockPlanId === undefined ? {} : { id: params.stockPlanId }),
     stock_class_ids: [params.stockClassId],
   });
 
@@ -496,14 +497,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: stockSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: stockSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -539,14 +540,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: stockSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: stockSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -582,14 +583,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: stockSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: stockSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -747,14 +748,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: convertibleSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: convertibleSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -849,14 +850,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: eqCompSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: eqCompSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -894,14 +895,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: eqCompSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: eqCompSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1138,14 +1139,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: stockSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: stockSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1186,14 +1187,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: stockSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: stockSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1228,14 +1229,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: stockSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: stockSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1309,14 +1310,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: stockSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: stockSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1352,14 +1353,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: stockSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: stockSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1398,14 +1399,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: convertibleSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: convertibleSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1442,14 +1443,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: convertibleSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: convertibleSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1486,14 +1487,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: eqCompSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: eqCompSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1528,14 +1529,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: eqCompSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: eqCompSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1570,14 +1571,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: eqCompSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: eqCompSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1692,14 +1693,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: warrantSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: warrantSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1734,14 +1735,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: warrantSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: warrantSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1776,14 +1777,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: warrantSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: warrantSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1857,14 +1858,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: warrantSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: warrantSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1901,14 +1902,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: stockSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: stockSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 
@@ -1943,14 +1944,14 @@ createIntegrationTestSuite('Production Data Round-Trip Tests', (getContext) => {
         ? {
             templateId: events.created.createdEvent.templateId,
             contractId: stockSecurity.capTableContractId,
-            createdEventBlob: events.created.createdEvent.createdEventBlob,
+            createdEventBlob: requireCreatedEventBlob(events.created.createdEvent),
             synchronizerId: issuerSetup.capTableContractDetails.synchronizerId,
           }
         : undefined;
 
       const batch = ctx.ocp.OpenCapTable.capTable.update({
         capTableContractId: stockSecurity.capTableContractId,
-        capTableContractDetails: updatedCapTableDetails,
+        ...withCapTableContractDetails(updatedCapTableDetails),
         actAs: [ctx.issuerParty],
       });
 

--- a/test/integration/utils/setupTestData.ts
+++ b/test/integration/utils/setupTestData.ts
@@ -83,6 +83,13 @@ export function generateTestId(prefix: string): string {
   return `${prefix}-${timestamp}-${random}`;
 }
 
+/** Omit optional disclosed-contract input rather than materializing it as `undefined`. */
+export function withCapTableContractDetails<T extends { templateId: string }>(
+  capTableContractDetails: T | undefined
+): { capTableContractDetails?: T } {
+  return capTableContractDetails === undefined ? {} : { capTableContractDetails };
+}
+
 /** Get updated CapTable contract details after a batch operation. */
 export async function getCapTableDetails(
   ocp: OcpClient,
@@ -405,8 +412,8 @@ export function createTestEquityCompensationIssuanceData(
     security_id: securityId,
     custom_id: `OPT-${securityId.substring(0, 8)}`,
     stakeholder_id,
-    stock_plan_id,
-    stock_class_id,
+    ...(stock_plan_id === undefined ? {} : { stock_plan_id }),
+    ...(stock_class_id === undefined ? {} : { stock_class_id }),
     compensation_type: 'OPTION_ISO',
     quantity: '50000',
     exercise_price: { amount: '0.50', currency: 'USD' },
@@ -823,7 +830,7 @@ export async function setupTestStakeholder(
   const cmd = buildUpdateCapTableCommand(
     {
       capTableContractId: options.issuerContractId,
-      capTableContractDetails: options.capTableContractDetails,
+      ...withCapTableContractDetails(options.capTableContractDetails),
     },
     { creates: [{ type: 'stakeholder', data: stakeholderData }] }
   );
@@ -1087,7 +1094,7 @@ export async function setupStockSecurity(
 
     const batch1 = ocp.OpenCapTable.capTable.update({
       capTableContractId,
-      capTableContractDetails,
+      ...withCapTableContractDetails(capTableContractDetails),
       actAs: [options.issuerParty],
     });
     const result1 = await batch1.create('stakeholder', stakeholderData).execute();
@@ -1113,7 +1120,7 @@ export async function setupStockSecurity(
 
     const batch2 = ocp.OpenCapTable.capTable.update({
       capTableContractId,
-      capTableContractDetails,
+      ...withCapTableContractDetails(capTableContractDetails),
       actAs: [options.issuerParty],
     });
     const result2 = await batch2.create('stockClass', stockClassData).execute();
@@ -1140,7 +1147,7 @@ export async function setupStockSecurity(
 
   const batch3 = ocp.OpenCapTable.capTable.update({
     capTableContractId,
-    capTableContractDetails,
+    ...withCapTableContractDetails(capTableContractDetails),
     actAs: [options.issuerParty],
   });
   const result3 = await batch3.create('stockIssuance', stockIssuanceData).execute();
@@ -1185,7 +1192,7 @@ export async function setupWarrantSecurity(
 
     const batch1 = ocp.OpenCapTable.capTable.update({
       capTableContractId,
-      capTableContractDetails,
+      ...withCapTableContractDetails(capTableContractDetails),
       actAs: [options.issuerParty],
     });
     const result1 = await batch1.create('stakeholder', stakeholderData).execute();
@@ -1211,7 +1218,7 @@ export async function setupWarrantSecurity(
 
   const batch2 = ocp.OpenCapTable.capTable.update({
     capTableContractId,
-    capTableContractDetails,
+    ...withCapTableContractDetails(capTableContractDetails),
     actAs: [options.issuerParty],
   });
   const result2 = await batch2.create('warrantIssuance', warrantIssuanceData).execute();
@@ -1257,7 +1264,7 @@ export async function setupEquityCompensationSecurity(
 
     const batch1 = ocp.OpenCapTable.capTable.update({
       capTableContractId,
-      capTableContractDetails,
+      ...withCapTableContractDetails(capTableContractDetails),
       actAs: [options.issuerParty],
     });
     const result1 = await batch1.create('stakeholder', stakeholderData).execute();
@@ -1283,7 +1290,7 @@ export async function setupEquityCompensationSecurity(
 
     const batch2 = ocp.OpenCapTable.capTable.update({
       capTableContractId,
-      capTableContractDetails,
+      ...withCapTableContractDetails(capTableContractDetails),
       actAs: [options.issuerParty],
     });
     const result2 = await batch2.create('stockClass', stockClassData).execute();
@@ -1310,7 +1317,7 @@ export async function setupEquityCompensationSecurity(
 
   const batch3 = ocp.OpenCapTable.capTable.update({
     capTableContractId,
-    capTableContractDetails,
+    ...withCapTableContractDetails(capTableContractDetails),
     actAs: [options.issuerParty],
   });
   const result3 = await batch3.create('equityCompensationIssuance', eqCompIssuanceData).execute();
@@ -1358,7 +1365,7 @@ export async function setupConvertibleSecurity(
 
     const batch1 = ocp.OpenCapTable.capTable.update({
       capTableContractId,
-      capTableContractDetails,
+      ...withCapTableContractDetails(capTableContractDetails),
       actAs: [options.issuerParty],
     });
     const result1 = await batch1.create('stakeholder', stakeholderData).execute();
@@ -1384,7 +1391,7 @@ export async function setupConvertibleSecurity(
 
   const batch2 = ocp.OpenCapTable.capTable.update({
     capTableContractId,
-    capTableContractDetails,
+    ...withCapTableContractDetails(capTableContractDetails),
     actAs: [options.issuerParty],
   });
   const result2 = await batch2.create('convertibleIssuance', convertibleIssuanceData).execute();

--- a/test/mocks/fairmint-canton-node-sdk.ts
+++ b/test/mocks/fairmint-canton-node-sdk.ts
@@ -4,7 +4,7 @@ import type { ClientConfig } from '@fairmint/canton-node-sdk';
 import type { SubmitAndWaitForTransactionTreeResponse } from '@fairmint/canton-node-sdk/build/src/clients/ledger-json-api/operations';
 
 export class LedgerJsonApiClient {
-  private readonly config?: ClientConfig;
+  private readonly config: ClientConfig | undefined;
   public static __instances: LedgerJsonApiClient[] = [];
   public lastAuthToken?: string;
   private __getAuthToken?: () => Promise<string> | string;
@@ -147,7 +147,7 @@ export class Canton {
   public readonly ledger: LedgerJsonApiClient;
   public readonly validator: ValidatorApiClient;
   public readonly scan: unknown;
-  private partyId?: string;
+  private partyId: string | undefined;
 
   constructor(public readonly config: ClientConfig) {
     this.ledger = new LedgerJsonApiClient(config);

--- a/test/validation/boundaries.test.ts
+++ b/test/validation/boundaries.test.ts
@@ -192,13 +192,12 @@ describe('Boundary Condition Tests', () => {
   });
 
   describe('Null vs Undefined Handling', () => {
-    test('DAML optional fields use null, not undefined', () => {
+    test('omitted OCF optional fields become null in DAML', () => {
       const data: OcfStakeholder = {
         id: 'sh-null-test',
         object_type: 'STAKEHOLDER',
         name: { legal_name: 'Test' },
         stakeholder_type: 'INDIVIDUAL',
-        issuer_assigned_id: undefined, // Should become null in DAML
       };
 
       const result = stakeholderDataToDaml(data);

--- a/tsconfig.exact-source.json
+++ b/tsconfig.exact-source.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "exactOptionalPropertyTypes": true,
-    "noEmit": true
-  },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "noImplicitReturns": true,
     "noImplicitOverride": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
## Summary

- enable `exactOptionalPropertyTypes` in the main TypeScript configuration for production and tests
- eliminate all 69 remaining exact-optional diagnostics by omitting absent values instead of assigning `undefined`
- remove the now-redundant source-only exactness configuration while preserving the public-config compile probe
- keep mocks mutable without unsafe assertions or type weakening

## Validation

- `npm run typecheck` — zero exact-optional diagnostics
- `npm run build`
- `npm run test:declarations`
- `npm run lint`
- `npm run format`
- `npm run test:ci` — 65 suites / 2,560 tests; 76.82% statements, 69.56% branches, 77.81% functions, 76.96% lines

## Stack

- stacked on #421

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad TypeScript strictness affects optional-property shapes across the public SDK and many call sites; the warrant PPS discount DAML mapping behavior changes slightly for edge cases around zero/empty discount amounts.
> 
> **Overview**
> Turns on **`exactOptionalPropertyTypes`** in the main **`tsconfig`** so production and test code share one stricter compile, and drops the separate **`test:exact-source`** / **`tsconfig.exact-source.json`** path now that **`typecheck`** no longer needs a second pass.
> 
> Call sites stop **materializing `undefined`** on optional fields: integration/setup helpers add **`withCapTableContractDetails`** (and similar conditional spreads) so absent disclosed-contract details and OCF fields are **omitted** rather than set to **`undefined`**. **`warrantMechanismToDaml`** for PPS discounts now keys off **`!== undefined`** for **`discount_percentage`** / **`discount_amount`** instead of **`in`** / truthiness checks.
> 
> Tests and mocks are aligned with the new rules—**`Parameters<>`** for ledger mocks, observability tests that **omit** per-call overrides, and **`requireCreatedEventBlob`** where blobs must be present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cbb2030eb2b93086ade31a7d3fcc9c3a2926405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->