### PR TITLE
Add first-class OCF Financing support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-captable-protocol/canton",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A TypeScript SDK for interacting with the Open CapTable Protocol (OCP) Factory contract on Canton blockchain",
   "repository": {
     "type": "git",
@@ -59,7 +59,7 @@
     "@apidevtools/json-schema-ref-parser": "15.3.5",
     "@eslint/eslintrc": "3.3.5",
     "@fairmint/canton-node-sdk": "0.0.227",
-    "@fairmint/open-captable-protocol-daml-js": "0.3.8",
+    "@fairmint/open-captable-protocol-daml-js": "0.3.13",
     "@types/jest": "30.0.0",
     "@types/jsonwebtoken": "9.0.10",
     "@types/node": "25.6.0",
@@ -82,7 +82,7 @@
   },
   "peerDependencies": {
     "@fairmint/canton-node-sdk": ">=0.0.223 <0.1.0",
-    "@fairmint/open-captable-protocol-daml-js": ">=0.3.8 <0.4.0"
+    "@fairmint/open-captable-protocol-daml-js": ">=0.3.13 <0.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -113,6 +113,7 @@ import type {
   OcfEquityCompensationRepricingOutput,
   OcfEquityCompensationRetractionOutput,
   OcfEquityCompensationTransferOutput,
+  OcfFinancingOutput,
   OcfIssuerAuthorizedSharesAdjustmentOutput,
   OcfIssuerOutput,
   OcfStakeholderOutput,
@@ -559,6 +560,7 @@ export class OcpClient {
       stockPlan: genericEntity('stockPlan'),
       vestingTerms: genericEntity('vestingTerms'),
       valuation: genericEntity('valuation'),
+      financing: genericEntity('financing'),
       document: genericEntity('document'),
 
       // ===== Issuances =====
@@ -671,6 +673,7 @@ export class OcpClient {
       CE_STAKEHOLDER_RELATIONSHIP: methods.stakeholderRelationshipChangeEvent,
       CE_STAKEHOLDER_STATUS: methods.stakeholderStatusChangeEvent,
       DOCUMENT: methods.document,
+      FINANCING: methods.financing,
       ISSUER: methods.issuer,
       STAKEHOLDER: methods.stakeholder,
       STOCK_CLASS: methods.stockClass,
@@ -873,6 +876,7 @@ interface OpenCapTableMethods {
   stockPlan: EntityReader<OcfStockPlanOutput>;
   vestingTerms: EntityReader<OcfVestingTermsOutput>;
   valuation: EntityReader<OcfValuationOutput>;
+  financing: EntityReader<OcfFinancingOutput>;
   document: EntityReader<OcfDocumentOutput>;
 
   // Issuances

--- a/src/functions/OpenCapTable/capTable/batchTypes.ts
+++ b/src/functions/OpenCapTable/capTable/batchTypes.ts
@@ -22,6 +22,7 @@ import type {
   OcfEquityCompensationRepricing,
   OcfEquityCompensationRetraction,
   OcfEquityCompensationTransfer,
+  OcfFinancing,
   OcfIssuer,
   OcfIssuerAuthorizedSharesAdjustment,
   OcfObjectType,
@@ -96,6 +97,7 @@ export type OcfEntityDataMap = {
   equityCompensationRepricing: OcfEquityCompensationRepricing;
   equityCompensationRetraction: OcfEquityCompensationRetraction;
   equityCompensationTransfer: OcfEquityCompensationTransfer;
+  financing: OcfFinancing;
   /** Issuer is edit-only (no create/delete) - created with CapTable via IssuerAuthorization */
   issuer: OcfIssuer;
   issuerAuthorizedSharesAdjustment: OcfIssuerAuthorizedSharesAdjustment;
@@ -324,6 +326,13 @@ export const ENTITY_REGISTRY = {
     dataField: 'transfer_data',
     capTableField: 'equity_compensation_transfers',
     operations: mutableEntityOperations('EquityCompensationTransfer'),
+  },
+  financing: {
+    objectType: 'FINANCING',
+    templateId: Fairmint.OpenCapTable.OCF.Financing.Financing.templateId,
+    dataField: 'financing_data',
+    capTableField: 'financings',
+    operations: mutableEntityOperations('Financing'),
   },
   issuer: {
     objectType: 'ISSUER',

--- a/src/functions/OpenCapTable/capTable/damlToOcf.ts
+++ b/src/functions/OpenCapTable/capTable/damlToOcf.ts
@@ -40,6 +40,7 @@ import { damlEquityCompensationReleaseToNative } from '../equityCompensationRele
 import { damlEquityCompensationRepricingToNative } from '../equityCompensationRepricing/damlToOcf';
 import { damlEquityCompensationRetractionToNative } from '../equityCompensationRetraction/damlToOcf';
 import { damlEquityCompensationTransferToNative } from '../equityCompensationTransfer/damlToOcf';
+import { damlFinancingToNative } from '../financing/damlToOcf';
 import { damlIssuerDataToNative } from '../issuer/getIssuerAsOcf';
 import { damlIssuerAuthorizedSharesAdjustmentDataToNative } from '../issuerAuthorizedSharesAdjustment/getIssuerAuthorizedSharesAdjustmentAsOcf';
 import { damlStakeholderDataToNative } from '../stakeholder/getStakeholderAsOcf';
@@ -117,6 +118,8 @@ export function convertToOcf(
     // ===== Core objects =====
     case 'document':
       return damlDocumentDataToNative(data as Parameters<typeof damlDocumentDataToNative>[0]);
+    case 'financing':
+      return damlFinancingToNative(data as Parameters<typeof damlFinancingToNative>[0]);
     case 'issuer':
       return damlIssuerDataToNative(data as Parameters<typeof damlIssuerDataToNative>[0]);
     case 'stakeholder':

--- a/src/functions/OpenCapTable/capTable/ocfToDaml.ts
+++ b/src/functions/OpenCapTable/capTable/ocfToDaml.ts
@@ -35,6 +35,7 @@ import { equityCompensationReleaseDataToDaml } from '../equityCompensationReleas
 import { equityCompensationRepricingDataToDaml } from '../equityCompensationRepricing/equityCompensationRepricingDataToDaml';
 import { equityCompensationRetractionDataToDaml } from '../equityCompensationRetraction/equityCompensationRetractionDataToDaml';
 import { equityCompensationTransferDataToDaml } from '../equityCompensationTransfer/equityCompensationTransferDataToDaml';
+import { financingDataToDaml } from '../financing/financingDataToDaml';
 import { issuerDataToDaml } from '../issuer/createIssuer';
 import { issuerAuthorizedSharesAdjustmentDataToDaml } from '../issuerAuthorizedSharesAdjustment/createIssuerAuthorizedSharesAdjustment';
 import { stakeholderDataToDaml } from '../stakeholder/stakeholderDataToDaml';
@@ -100,6 +101,8 @@ function convertEntityToDaml(type: OcfEntityType, data: OcfDataTypeFor<OcfEntity
       return vestingTermsDataToDaml(d as OcfDataTypeFor<'vestingTerms'>);
     case 'document':
       return documentDataToDaml(d as OcfDataTypeFor<'document'>);
+    case 'financing':
+      return financingDataToDaml(d as OcfDataTypeFor<'financing'>);
     case 'stockLegendTemplate':
       return stockLegendTemplateDataToDaml(d as OcfDataTypeFor<'stockLegendTemplate'>);
     case 'stockPlan':

--- a/src/functions/OpenCapTable/financing/damlToOcf.ts
+++ b/src/functions/OpenCapTable/financing/damlToOcf.ts
@@ -1,0 +1,15 @@
+import type { Fairmint } from '@fairmint/open-captable-protocol-daml-js';
+import type { OcfFinancing } from '../../../types';
+import { damlTimeToDateString } from '../../../utils/typeConversions';
+
+/** Convert generated DAML Financing data back to canonical OCF. */
+export function damlFinancingToNative(financing: Fairmint.OpenCapTable.OCF.Financing.FinancingOcfData): OcfFinancing {
+  return {
+    object_type: 'FINANCING',
+    id: financing.id,
+    date: damlTimeToDateString(financing.date),
+    name: financing.name,
+    issuance_ids: financing.issuance_ids,
+    ...(financing.comments.length > 0 && { comments: financing.comments }),
+  };
+}

--- a/src/functions/OpenCapTable/financing/financingDataToDaml.ts
+++ b/src/functions/OpenCapTable/financing/financingDataToDaml.ts
@@ -1,0 +1,14 @@
+import type { Fairmint } from '@fairmint/open-captable-protocol-daml-js';
+import type { OcfFinancing } from '../../../types';
+import { cleanComments, dateStringToDAMLTime } from '../../../utils/typeConversions';
+
+/** Convert canonical OCF Financing data to the generated DAML representation. */
+export function financingDataToDaml(financing: OcfFinancing): Fairmint.OpenCapTable.OCF.Financing.FinancingOcfData {
+  return {
+    id: financing.id,
+    date: dateStringToDAMLTime(financing.date),
+    name: financing.name,
+    comments: cleanComments(financing.comments),
+    issuance_ids: financing.issuance_ids,
+  };
+}

--- a/src/functions/OpenCapTable/financing/index.ts
+++ b/src/functions/OpenCapTable/financing/index.ts
@@ -1,0 +1,2 @@
+export { damlFinancingToNative } from './damlToOcf';
+export { financingDataToDaml } from './financingDataToDaml';

--- a/src/functions/OpenCapTable/index.ts
+++ b/src/functions/OpenCapTable/index.ts
@@ -15,6 +15,7 @@ export * from './equityCompensationRepricing';
 export * from './equityCompensationRetraction';
 export * from './equityCompensationTransfer';
 export * from './factory';
+export * from './financing';
 export * from './issuer';
 export * from './issuerAuthorization';
 export * from './issuerAuthorizedSharesAdjustment';

--- a/src/utils/cantonOcfExtractor.ts
+++ b/src/utils/cantonOcfExtractor.ts
@@ -355,6 +355,7 @@ export interface OcfManifest {
   vestingTerms: Array<Record<string, unknown>>;
   valuations: Array<Record<string, unknown>>;
   documents: Array<Record<string, unknown>>;
+  financings: Array<Record<string, unknown>>;
   stockLegendTemplates: Array<Record<string, unknown>>;
 }
 
@@ -426,6 +427,7 @@ export async function extractCantonOcfManifest(
     vestingTerms: [],
     valuations: [],
     documents: [],
+    financings: [],
     stockLegendTemplates: [],
   };
 
@@ -546,6 +548,9 @@ export async function extractCantonOcfManifest(
           } else if (entityType === 'document') {
             const { document } = await getDocumentAsOcf(client, { contractId, ...readScopeOpts });
             result.documents.push(document as unknown as Record<string, unknown>);
+          } else if (entityType === 'financing') {
+            const { data } = await getEntityAsOcf(client, 'financing', contractId, readScopeOpts);
+            result.financings.push(data as unknown as Record<string, unknown>);
           } else if (entityType === 'stockLegendTemplate') {
             const { stockLegendTemplate } = await getStockLegendTemplateAsOcf(client, {
               contractId,
@@ -631,6 +636,7 @@ export function countManifestObjects(manifest: Partial<OcfManifest>): number {
   count += (manifest.transactions ?? []).length;
   count += (manifest.valuations ?? []).length;
   count += (manifest.documents ?? []).length;
+  count += (manifest.financings ?? []).length;
   count += (manifest.stockLegendTemplates ?? []).length;
   return count;
 }

--- a/src/utils/replicationHelpers.ts
+++ b/src/utils/replicationHelpers.ts
@@ -32,6 +32,7 @@ export { isOcfEntityType } from '../functions/OpenCapTable/capTable/batchTypes';
  */
 const OBJECT_TYPES: Record<string, OcfEntityType> = {
   DOCUMENT: 'document',
+  FINANCING: 'financing',
   VESTING_TERMS: 'vestingTerms',
   STOCK_LEGEND_TEMPLATE: 'stockLegendTemplate',
   VALUATION: 'valuation',
@@ -183,6 +184,7 @@ const ENTITY_TYPE_LABELS: Record<OcfEntityType, [string, string]> = {
   vestingTerms: ['Vesting Terms', 'Vesting Terms'],
   stockLegendTemplate: ['Stock Legend Template', 'Stock Legend Templates'],
   document: ['Document', 'Documents'],
+  financing: ['Financing', 'Financings'],
   valuation: ['Valuation', 'Valuations'],
 
   // Stock Transactions (9 types)
@@ -332,6 +334,9 @@ export function buildCantonOcfDataMap(manifest: OcfManifest): CantonOcfDataMap {
   }
   for (const document of manifest.documents) {
     addItem('document', document, 'document');
+  }
+  for (const financing of manifest.financings) {
+    addItem('financing', financing, 'financing');
   }
   for (const stockLegendTemplate of manifest.stockLegendTemplates) {
     addItem('stockLegendTemplate', stockLegendTemplate, 'stockLegendTemplate');

--- a/test/batch/CapTableBatch.test.ts
+++ b/test/batch/CapTableBatch.test.ts
@@ -814,10 +814,10 @@ describe('ENTITY_TAG_MAP', () => {
     });
   });
 
-  it('should have all 48 canonical entity types', () => {
+  it('should have all 49 canonical entity types', () => {
     // Schema-supported PlanSecurity values normalize to EquityCompensation before typed batch operations.
     // Issuer is the one edit-only entity stored as a single reference rather than a map.
-    expect(Object.keys(ENTITY_TAG_MAP)).toHaveLength(48);
+    expect(Object.keys(ENTITY_TAG_MAP)).toHaveLength(49);
   });
 
   it('should have correct tags for stakeholder event types', () => {

--- a/test/batch/generatedOperationConstruction.test.ts
+++ b/test/batch/generatedOperationConstruction.test.ts
@@ -47,6 +47,7 @@ const editableFixtures: readonly OcfEditArguments[] = [
   loadEntityFixture('equityCompensationRepricing', 'synthetic/equityCompensationRepricing.json'),
   loadEntityFixture('equityCompensationRetraction', 'synthetic/equityCompensationRetraction.json'),
   loadEntityFixture('equityCompensationTransfer', 'synthetic/equityCompensationTransfer.json'),
+  loadEntityFixture('financing', 'production/financing/basic.json'),
   loadEntityFixture('issuer', 'production/issuer/basic.json'),
   loadEntityFixture('issuerAuthorizedSharesAdjustment', 'production/issuerAuthorizedSharesAdjustment.json'),
   loadEntityFixture('stakeholder', 'production/stakeholder/individual.json'),

--- a/test/capTable/getCapTableState.test.ts
+++ b/test/capTable/getCapTableState.test.ts
@@ -156,6 +156,7 @@ describe('getCapTableState', () => {
                   stock_legend_templates: [],
                   documents: [],
                   valuations: [],
+                  financings: [['financing-1', 'financing-contract-1']],
                   stock_issuances: [['stock-issuance-1', 'stock-issuance-contract-1']],
                   stock_cancellations: [],
                   stock_transfers: [],
@@ -237,6 +238,11 @@ describe('getCapTableState', () => {
       expect(stockIssuances).toBeDefined();
       expect(stockIssuances!.size).toBe(1);
       expect(stockIssuances!.has('stock-issuance-1')).toBe(true);
+
+      // Financing is stored in the optional CapTable map introduced in OpenCapTable-v34 0.0.3.
+      const financings = result!.entities.get('financing');
+      expect(financings).toEqual(new Set(['financing-1']));
+      expect(result!.contractIds.get('financing')?.get('financing-1')).toBe('financing-contract-1');
 
       // Verify contractIds map is also populated
       const stakeholderContractIds = result!.contractIds.get('stakeholder');

--- a/test/converters/financingConverters.test.ts
+++ b/test/converters/financingConverters.test.ts
@@ -1,0 +1,55 @@
+import {
+  buildOcfCreateData,
+  convertToOcf,
+  damlFinancingToNative,
+  financingDataToDaml,
+  type OcfFinancing,
+} from '../../src';
+
+describe('Financing converters', () => {
+  const financing: OcfFinancing = {
+    object_type: 'FINANCING',
+    id: 'financing-series-a',
+    name: 'Series A',
+    issuance_ids: ['stock-issuance-1', 'convertible-issuance-1'],
+    date: '2026-01-15',
+    comments: ['Initial close'],
+  };
+
+  it('maps the canonical OCF representation to generated DAML data', () => {
+    expect(financingDataToDaml(financing)).toEqual({
+      id: 'financing-series-a',
+      name: 'Series A',
+      issuance_ids: ['stock-issuance-1', 'convertible-issuance-1'],
+      date: '2026-01-15T00:00:00.000Z',
+      comments: ['Initial close'],
+    });
+  });
+
+  it('round-trips through the generic dispatchers', () => {
+    const damlData = buildOcfCreateData('financing', financing).value;
+
+    expect(convertToOcf('financing', damlData)).toEqual(financing);
+  });
+
+  it('normalizes absent comments at the representation boundary', () => {
+    const withoutComments: OcfFinancing = {
+      ...financing,
+      comments: undefined,
+    };
+    const damlData = financingDataToDaml(withoutComments);
+
+    expect(damlData.comments).toEqual([]);
+    expect(damlFinancingToNative(damlData)).toEqual(withoutComments);
+  });
+
+  it('does not preflight issuance references that the DAML contract owns', () => {
+    const create = buildOcfCreateData('financing', {
+      ...financing,
+      issuance_ids: ['not-present-on-this-cap-table'],
+    });
+
+    expect(create.tag).toBe('OcfCreateFinancing');
+    expect(create.value.issuance_ids).toEqual(['not-present-on-this-cap-table']);
+  });
+});

--- a/test/converters/financingConverters.test.ts
+++ b/test/converters/financingConverters.test.ts
@@ -34,8 +34,11 @@ describe('Financing converters', () => {
 
   it('normalizes absent comments at the representation boundary', () => {
     const withoutComments: OcfFinancing = {
-      ...financing,
-      comments: undefined,
+      object_type: 'FINANCING',
+      id: 'financing-series-a',
+      name: 'Series A',
+      issuance_ids: ['stock-issuance-1', 'convertible-issuance-1'],
+      date: '2026-01-15',
     };
     const damlData = financingDataToDaml(withoutComments);
 

--- a/test/declarations/generatedOperationConstruction.types.ts
+++ b/test/declarations/generatedOperationConstruction.types.ts
@@ -8,16 +8,21 @@ import {
   type OcfCreateDataFor,
   type OcfDeleteDataFor,
   type OcfEditDataFor,
+  type OcfFinancing,
   type OcfIssuer,
   type OcfStakeholder,
 } from '../../dist';
 
 declare const stakeholder: OcfStakeholder;
+declare const financing: OcfFinancing;
 declare const issuer: OcfIssuer;
 
 const create: OcfCreateDataFor<'stakeholder'> = buildOcfCreateData('stakeholder', stakeholder);
 const edit: OcfEditDataFor<'issuer'> = buildOcfEditData('issuer', issuer);
 const deletion: OcfDeleteDataFor<'stakeholder'> = buildOcfDeleteData('stakeholder', stakeholder.id);
+const financingCreate: OcfCreateDataFor<'financing'> = buildOcfCreateData('financing', financing);
+const financingEdit: OcfEditDataFor<'financing'> = buildOcfEditData('financing', financing);
+const financingDelete: OcfDeleteDataFor<'financing'> = buildOcfDeleteData('financing', financing.id);
 
 const createTag: 'OcfCreateStakeholder' = create.tag;
 const editTag: 'OcfEditIssuer' = edit.tag;
@@ -25,6 +30,10 @@ const deleteTag: 'OcfDeleteStakeholder' = deletion.tag;
 const createValue: Fairmint.OpenCapTable.OCF.Stakeholder.StakeholderOcfData = create.value;
 const editValue: Fairmint.OpenCapTable.OCF.Issuer.IssuerOcfData = edit.value;
 const deleteValue: string = deletion.value;
+const financingCreateTag: 'OcfCreateFinancing' = financingCreate.tag;
+const financingEditTag: 'OcfEditFinancing' = financingEdit.tag;
+const financingDeleteTag: 'OcfDeleteFinancing' = financingDelete.tag;
+const financingCreateValue: Fairmint.OpenCapTable.OCF.Financing.FinancingOcfData = financingCreate.value;
 
 void createTag;
 void editTag;
@@ -32,3 +41,7 @@ void deleteTag;
 void createValue;
 void editValue;
 void deleteValue;
+void financingCreateTag;
+void financingEditTag;
+void financingDeleteTag;
+void financingCreateValue;

--- a/test/declarations/publicApi.types.ts
+++ b/test/declarations/publicApi.types.ts
@@ -28,7 +28,7 @@ import {
 
 type Assert<T extends true> = T;
 type IsExactly<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
-type IntendedCanonicalOcfObject = OcfEntityDataMap[OcfEntityType] | OcfFinancing;
+type IntendedCanonicalOcfObject = OcfEntityDataMap[OcfEntityType];
 type SchemaSupportedPlanSecurityObjectType =
   | 'TX_PLAN_SECURITY_ACCEPTANCE'
   | 'TX_PLAN_SECURITY_CANCELLATION'
@@ -64,6 +64,7 @@ function verifyPublishedBatchApi(
   batch: CapTableBatch,
   stakeholder: OcfStakeholder,
   stockClass: OcfStockClass,
+  financing: OcfFinancing,
   issuer: OcfIssuer,
   stockAcceptance: OcfStockAcceptance,
   warrantAcceptance: OcfWarrantAcceptance,
@@ -72,6 +73,9 @@ function verifyPublishedBatchApi(
 ): void {
   batch.create('stakeholder', stakeholder);
   batch.create('stockClass', stockClass);
+  batch.create('financing', financing);
+  batch.edit('financing', financing);
+  batch.delete('financing', financing.id);
   batch.edit('issuer', issuer);
   batch.delete('stakeholder', stakeholder.id);
 

--- a/test/fixtures/production/financing/basic.json
+++ b/test/fixtures/production/financing/basic.json
@@ -1,0 +1,8 @@
+{
+  "object_type": "FINANCING",
+  "id": "financing-series-a",
+  "name": "Series A",
+  "issuance_ids": ["stock-issuance-series-a", "convertible-issuance-series-a"],
+  "date": "2026-01-15",
+  "comments": ["Initial close"]
+}

--- a/test/integration/entities/financing.integration.test.ts
+++ b/test/integration/entities/financing.integration.test.ts
@@ -1,0 +1,124 @@
+import type { OcfFinancing } from '../../../src';
+import { createIntegrationTestSuite } from '../setup';
+import { generateDateString, generateTestId, getCapTableDetails, setupStockSecurity, setupTestIssuer } from '../utils';
+
+function requireTaggedContractId(values: readonly unknown[], expectedTag: string): string {
+  for (const value of values) {
+    if (value && typeof value === 'object' && 'tag' in value && 'value' in value) {
+      const tagged = value as { tag?: unknown; value?: unknown };
+      if (tagged.tag === expectedTag && typeof tagged.value === 'string') return tagged.value;
+    }
+  }
+  throw new Error(`Missing ${expectedTag} contract ID`);
+}
+
+createIntegrationTestSuite('Financing operations', (getContext) => {
+  test('creates, reads, edits, and deletes a Financing that references an issuance', async () => {
+    const ctx = getContext();
+    const issuer = await setupTestIssuer(ctx.ocp, {
+      systemOperatorParty: ctx.systemOperatorParty,
+      ocpFactoryContractId: ctx.ocpFactoryContractId,
+      issuerParty: ctx.issuerParty,
+    });
+    const stock = await setupStockSecurity(ctx.ocp, {
+      issuerContractId: issuer.issuerContractId,
+      issuerParty: ctx.issuerParty,
+      capTableContractDetails: issuer.capTableContractDetails,
+    });
+    const { data: issuance } = await ctx.ocp.OpenCapTable.stockIssuance.get({
+      contractId: stock.stockIssuanceContractId,
+    });
+    const { synchronizerId } = issuer.capTableContractDetails;
+    const stockCapTableDetails = await getCapTableDetails(ctx.ocp, stock.capTableContractId, synchronizerId);
+    const financing: OcfFinancing = {
+      object_type: 'FINANCING',
+      id: generateTestId('financing'),
+      name: 'Series A',
+      issuance_ids: [issuance.id],
+      date: generateDateString(),
+    };
+
+    const created = await ctx.ocp.OpenCapTable.capTable
+      .update({
+        capTableContractId: stock.capTableContractId,
+        capTableContractDetails: stockCapTableDetails,
+        actAs: [ctx.issuerParty],
+      })
+      .create('financing', financing)
+      .execute();
+    const financingContractId = requireTaggedContractId(created.createdCids, 'CidFinancing');
+
+    await expect(ctx.ocp.OpenCapTable.financing.get({ contractId: financingContractId })).resolves.toMatchObject({
+      data: financing,
+      contractId: financingContractId,
+    });
+
+    const createdCapTableDetails = await getCapTableDetails(ctx.ocp, created.updatedCapTableCid, synchronizerId);
+    const editedData = { ...financing, name: 'Series A Final Close' };
+    const edited = await ctx.ocp.OpenCapTable.capTable
+      .update({
+        capTableContractId: created.updatedCapTableCid,
+        capTableContractDetails: createdCapTableDetails,
+        actAs: [ctx.issuerParty],
+      })
+      .edit('financing', editedData)
+      .execute();
+    const editedContractId = requireTaggedContractId(edited.editedCids, 'CidFinancing');
+
+    await expect(ctx.ocp.OpenCapTable.financing.get({ contractId: editedContractId })).resolves.toMatchObject({
+      data: editedData,
+      contractId: editedContractId,
+    });
+
+    const editedCapTableDetails = await getCapTableDetails(ctx.ocp, edited.updatedCapTableCid, synchronizerId);
+    await expect(
+      ctx.ocp.OpenCapTable.capTable
+        .update({
+          capTableContractId: edited.updatedCapTableCid,
+          capTableContractDetails: editedCapTableDetails,
+          actAs: [ctx.issuerParty],
+        })
+        .delete('financing', financing.id)
+        .execute()
+    ).resolves.toMatchObject({ updatedCapTableCid: expect.any(String) });
+  });
+
+  test('leaves missing issuance reference rejection to DAML', async () => {
+    const ctx = getContext();
+    const issuer = await setupTestIssuer(ctx.ocp, {
+      systemOperatorParty: ctx.systemOperatorParty,
+      ocpFactoryContractId: ctx.ocpFactoryContractId,
+      issuerParty: ctx.issuerParty,
+    });
+    const financingId = generateTestId('invalid-financing');
+    const missingIssuanceId = generateTestId('missing-issuance');
+    const batch = ctx.ocp.OpenCapTable.capTable
+      .update({
+        capTableContractId: issuer.issuerContractId,
+        capTableContractDetails: issuer.capTableContractDetails,
+        actAs: [ctx.issuerParty],
+      })
+      .create('financing', {
+        object_type: 'FINANCING',
+        id: financingId,
+        name: 'Invalid round',
+        issuance_ids: [missingIssuanceId],
+        date: generateDateString(),
+      });
+
+    expect(() => batch.build()).not.toThrow();
+    let rejection: unknown;
+    try {
+      await batch.execute();
+    } catch (error: unknown) {
+      rejection = error;
+    }
+
+    if (!(rejection instanceof Error)) {
+      throw new Error('Expected DAML to reject the missing Financing issuance reference');
+    }
+    expect(rejection.message).toContain(
+      `Financing ${financingId} issuance reference must match exactly one issuance object: ${missingIssuanceId} (matches 0)`
+    );
+  });
+});

--- a/test/integration/entities/financing.integration.test.ts
+++ b/test/integration/entities/financing.integration.test.ts
@@ -124,6 +124,7 @@ createIntegrationTestSuite('Financing operations', (getContext) => {
     });
     expect(rejection.cause?.message).toContain('DAML_FAILURE');
     expect(rejection.cause?.message).toContain('AssertionFailed');
-    expect(rejection.message).toContain(`Financing ${financingId} issuance reference must matc`);
+    expect(rejection.message).toContain(`Financing ${financingId} issuance reference must`);
+    expect(rejection.message).toContain('types: Financing');
   });
 });

--- a/test/integration/entities/financing.integration.test.ts
+++ b/test/integration/entities/financing.integration.test.ts
@@ -1,4 +1,4 @@
-import type { OcfFinancing } from '../../../src';
+import { OcpContractError, OcpErrorCodes, type OcfFinancing } from '../../../src';
 import { createIntegrationTestSuite } from '../setup';
 import { generateDateString, generateTestId, getCapTableDetails, setupStockSecurity, setupTestIssuer } from '../utils';
 
@@ -94,7 +94,7 @@ createIntegrationTestSuite('Financing operations', (getContext) => {
     const missingIssuanceId = generateTestId('missing-issuance');
     const batch = ctx.ocp.OpenCapTable.capTable
       .update({
-        capTableContractId: issuer.issuerContractId,
+        capTableContractId: issuer.capTableContractDetails.contractId,
         capTableContractDetails: issuer.capTableContractDetails,
         actAs: [ctx.issuerParty],
       })
@@ -114,11 +114,16 @@ createIntegrationTestSuite('Financing operations', (getContext) => {
       rejection = error;
     }
 
-    if (!(rejection instanceof Error)) {
+    if (!(rejection instanceof OcpContractError)) {
       throw new Error('Expected DAML to reject the missing Financing issuance reference');
     }
-    expect(rejection.message).toContain(
-      `Financing ${financingId} issuance reference must match exactly one issuance object: ${missingIssuanceId} (matches 0)`
-    );
+    expect(rejection).toMatchObject({
+      code: OcpErrorCodes.CHOICE_FAILED,
+      classification: 'contract_error',
+      choice: 'UpdateCapTable',
+    });
+    expect(rejection.cause?.message).toContain('DAML_FAILURE');
+    expect(rejection.cause?.message).toContain('AssertionFailed');
+    expect(rejection.message).toContain(`Financing ${financingId} issuance reference must matc`);
   });
 });

--- a/test/types/capTableBatch.types.ts
+++ b/test/types/capTableBatch.types.ts
@@ -26,7 +26,7 @@ import {
 
 type Assert<T extends true> = T;
 type IsExactly<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
-type IntendedCanonicalOcfObject = OcfEntityDataMap[OcfEntityType] | OcfFinancing;
+type IntendedCanonicalOcfObject = OcfEntityDataMap[OcfEntityType];
 type LegacyPlanSecurityObjectType =
   | 'TX_PLAN_SECURITY_ACCEPTANCE'
   | 'TX_PLAN_SECURITY_CANCELLATION'
@@ -48,6 +48,7 @@ function verifyCapTableBatchContract(
   batch: CapTableBatch,
   stakeholder: OcfStakeholder,
   stockClass: OcfStockClass,
+  financing: OcfFinancing,
   issuer: OcfIssuer,
   stockAcceptance: OcfStockAcceptance,
   warrantAcceptance: OcfWarrantAcceptance,
@@ -56,6 +57,9 @@ function verifyCapTableBatchContract(
 ): void {
   batch.create('stakeholder', stakeholder);
   batch.create('stockClass', stockClass);
+  batch.create('financing', financing);
+  batch.edit('financing', financing);
+  batch.delete('financing', financing.id);
   batch.edit('issuer', issuer);
   batch.delete('stakeholder', stakeholder.id);
 

--- a/test/types/generatedOperationConstruction.types.ts
+++ b/test/types/generatedOperationConstruction.types.ts
@@ -11,6 +11,7 @@ import {
   type OcfDeleteDataFor,
   type OcfEditData,
   type OcfEditDataFor,
+  type OcfFinancing,
   type OcfIssuer,
   type OcfStakeholder,
   type OcfStockClass,
@@ -19,6 +20,7 @@ import {
 function verifyGeneratedOperationBuilders(
   stakeholder: OcfStakeholder,
   stockClass: OcfStockClass,
+  financing: OcfFinancing,
   issuer: OcfIssuer
 ): void {
   const create: OcfCreateData = buildOcfCreateData('stakeholder', stakeholder);
@@ -27,12 +29,19 @@ function verifyGeneratedOperationBuilders(
   const exactCreate: OcfCreateDataFor<'stakeholder'> = buildOcfCreateData('stakeholder', stakeholder);
   const exactEdit: OcfEditDataFor<'issuer'> = buildOcfEditData('issuer', issuer);
   const exactDelete: OcfDeleteDataFor<'stakeholder'> = buildOcfDeleteData('stakeholder', stakeholder.id);
+  const financingCreate: OcfCreateDataFor<'financing'> = buildOcfCreateData('financing', financing);
+  const financingEdit: OcfEditDataFor<'financing'> = buildOcfEditData('financing', financing);
+  const financingDelete: OcfDeleteDataFor<'financing'> = buildOcfDeleteData('financing', financing.id);
   const exactCreateTag: 'OcfCreateStakeholder' = exactCreate.tag;
   const exactEditTag: 'OcfEditIssuer' = exactEdit.tag;
   const exactDeleteTag: 'OcfDeleteStakeholder' = exactDelete.tag;
   const exactCreateValue: Fairmint.OpenCapTable.OCF.Stakeholder.StakeholderOcfData = exactCreate.value;
   const exactEditValue: Fairmint.OpenCapTable.OCF.Issuer.IssuerOcfData = exactEdit.value;
   const exactDeleteValue: string = exactDelete.value;
+  const financingCreateTag: 'OcfCreateFinancing' = financingCreate.tag;
+  const financingEditTag: 'OcfEditFinancing' = financingEdit.tag;
+  const financingDeleteTag: 'OcfDeleteFinancing' = financingDelete.tag;
+  const financingCreateValue: Fairmint.OpenCapTable.OCF.Financing.FinancingOcfData = financingCreate.value;
   void create;
   void edit;
   void deletion;
@@ -42,6 +51,10 @@ function verifyGeneratedOperationBuilders(
   void exactCreateValue;
   void exactEditValue;
   void exactDeleteValue;
+  void financingCreateTag;
+  void financingEditTag;
+  void financingDeleteTag;
+  void financingCreateValue;
 
   // @ts-expect-error create builders preserve entity-kind/payload correlation
   buildOcfCreateData('stockClass', stakeholder);

--- a/test/utils/countManifestObjects.test.ts
+++ b/test/utils/countManifestObjects.test.ts
@@ -10,13 +10,14 @@ describe('countManifestObjects', () => {
     transactions: [{ id: 't1' }, { id: 't2' }, { id: 't3' }] as OcfManifest['transactions'],
     valuations: [{ id: 'v1' }] as OcfManifest['valuations'],
     documents: [{ id: 'd1' }, { id: 'd2' }] as OcfManifest['documents'],
+    financings: [{ id: 'f1' }] as OcfManifest['financings'],
     stockLegendTemplates: [] as OcfManifest['stockLegendTemplates'],
   };
 
   test('counts all objects in a full manifest', () => {
     // 1 issuer + 2 stakeholders + 1 stockClass + 0 stockPlans + 1 vestingTerms
-    // + 3 transactions + 1 valuation + 2 documents + 0 stockLegendTemplates = 11
-    expect(countManifestObjects(fullManifest)).toBe(11);
+    // + 3 transactions + 1 valuation + 2 documents + 1 financing + 0 stockLegendTemplates = 12
+    expect(countManifestObjects(fullManifest)).toBe(12);
   });
 
   test('handles partial manifest missing valuations, documents, and stockLegendTemplates', () => {

--- a/test/utils/replicationHelpers.test.ts
+++ b/test/utils/replicationHelpers.test.ts
@@ -173,6 +173,10 @@ describe('mapCategorizedTypeToEntityType', () => {
       expect(mapCategorizedTypeToEntityType('DOCUMENT', null)).toBe('document');
     });
 
+    it('maps FINANCING directly', () => {
+      expect(mapCategorizedTypeToEntityType('FINANCING', null)).toBe('financing');
+    });
+
     it('maps VESTING_TERMS directly', () => {
       expect(mapCategorizedTypeToEntityType('VESTING_TERMS', null)).toBe('vestingTerms');
     });
@@ -189,6 +193,10 @@ describe('mapCategorizedTypeToEntityType', () => {
   describe('OBJECT category subtypes', () => {
     it('maps OBJECT/DOCUMENT to document', () => {
       expect(mapCategorizedTypeToEntityType('OBJECT', 'DOCUMENT')).toBe('document');
+    });
+
+    it('maps OBJECT/FINANCING to financing', () => {
+      expect(mapCategorizedTypeToEntityType('OBJECT', 'FINANCING')).toBe('financing');
     });
 
     it('maps OBJECT/VESTING_TERMS to vestingTerms', () => {
@@ -270,6 +278,10 @@ describe('getEntityTypeLabel', () => {
     it('returns singular for stockIssuance', () => {
       expect(getEntityTypeLabel('stockIssuance', 1)).toBe('1 Stock Issuance');
     });
+
+    it('returns singular for financing', () => {
+      expect(getEntityTypeLabel('financing', 1)).toBe('1 Financing');
+    });
   });
 
   describe('plural labels (count != 1)', () => {
@@ -313,6 +325,7 @@ describe('buildCantonOcfDataMap', () => {
     vestingTerms: [],
     valuations: [],
     documents: [],
+    financings: [],
     stockLegendTemplates: [],
   });
 
@@ -404,6 +417,18 @@ describe('buildCantonOcfDataMap', () => {
       const result = buildCantonOcfDataMap(manifest);
 
       expect(result.get('document')?.get('doc-1')).toEqual({ id: 'doc-1', name: 'Stock Purchase Agreement' });
+    });
+
+    it('adds financings to the map', () => {
+      const manifest = createEmptyManifest();
+      manifest.financings = [{ id: 'financing-1', issuance_ids: ['issuance-1'] }];
+
+      const result = buildCantonOcfDataMap(manifest);
+
+      expect(result.get('financing')?.get('financing-1')).toEqual({
+        id: 'financing-1',
+        issuance_ids: ['issuance-1'],
+      });
     });
 
     it('adds stockLegendTemplates to the map', () => {
@@ -535,6 +560,28 @@ describe('computeReplicationDiff', () => {
   });
 
   describe('create detection', () => {
+    it('treats financing as an ordinary contract-backed create without reference preflight', () => {
+      const financing = {
+        object_type: 'FINANCING',
+        id: 'financing-1',
+        name: 'Series A',
+        issuance_ids: ['missing-issuance'],
+        date: '2026-01-15',
+      };
+
+      const diff = computeReplicationDiff([{ entityType: 'financing', data: financing }], createEmptyCantonState());
+
+      expect(diff.creates).toEqual([
+        {
+          id: 'financing-1',
+          entityType: 'financing',
+          operation: 'create',
+          data: financing,
+        },
+      ]);
+      expect(diff.conflicts).toEqual([]);
+    });
+
     it('detects items in source but not in Canton as creates', () => {
       const sourceItems: SourceReplicationItem[] = [
         { entityType: 'stakeholder', data: { id: 'sh-1', name: 'Alice' } },


### PR DESCRIPTION
## What
- add Financing to the typed OCF entity registry, batch operations, public readers, cap-table state, extraction, and replication helpers
- add bidirectional generated-DAML converters and focused unit, declaration, and LocalNet integration coverage
- consume `@fairmint/open-captable-protocol-daml-js@0.3.13` and publish this additive public surface as SDK `0.7.0`

## Validation authority
The SDK only converts and submits Financing objects. It does not preflight or filter issuance references. The integration test proves a missing issuance passes SDK batch construction and is then rejected by the DAML contract with the specific reference-invariant diagnostic.

## Why
The database replay includes Financing objects, but SDK 0.6.0 cannot map them. This completes first-class OCF object coverage so the replay exercises the authoritative contract validation instead of skipping Financing.

## Validation
- `npm run fix`
- `npm run test:ci` — 60 suites, 2,774 tests
- `npm run build`
- `npm run test:declarations`
- focused converter/registry/state/replication suites — 362 tests
- `npm pack --dry-run` confirms Financing output is included

Local LocalNet startup requires an interactive sudo edit to `/etc/hosts`, so the CI QuickStart job is the authoritative integration gate for this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the central entity registry, batch API, and replication paths used for DB→Canton sync; behavior is additive but incorrect issuance handling only surfaces at DAML submit time.
> 
> **Overview**
> Adds **OCF Financing** as a full SDK entity so cap-table replay and Canton sync can create, read, edit, and delete financing rounds instead of skipping them.
> 
> **`financing`** is wired through `ENTITY_REGISTRY` (CapTable `financings` map, `OcfCreate/Edit/DeleteFinancing` tags), `OcpClient.OpenCapTable.financing` and `FINANCING` in `getByObjectType`, and the shared `convertToOcf` / `convertToDaml` dispatchers via new bidirectional converters (`id`, `name`, `date`, `issuance_ids`, optional `comments`). Extraction (`OcfManifest.financings`), replication type mapping, and manifest counting/diff building include financings; replication treats them like other contract-backed objects and does **not** preflight `issuance_ids`—invalid references fail on the ledger.
> 
> Bumps **`@open-captable-protocol/canton` to 0.7.0** and requires **`@fairmint/open-captable-protocol-daml-js` ≥ 0.3.13**. Public `OcfObject` / batch typings now treat Financing as a normal registry entity (no separate union). Tests cover converters, batch registry size (49 entities), cap-table state, replication, declarations, and LocalNet integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7382f8b758a74dac7d8d641a45b43fa7efd80396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for financing records across cap table operations.
  * Create, view, edit, and delete financing entries, including issuance references.
  * Added financing data to cap table state, extracted manifests, and replication workflows.
  * Added conversion support between OCF and DAML financing formats.
  * Updated the SDK to version 0.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->