### PR TITLE
Preserve stock-class conversion rounding

### DIFF
--- a/src/functions/OpenCapTable/stockClass/getStockClassAsOcf.ts
+++ b/src/functions/OpenCapTable/stockClass/getStockClassAsOcf.ts
@@ -9,7 +9,7 @@ import type {
   OcfStockClass,
   StockClassConversionRight,
 } from '../../../types/native';
-import { damlStockClassTypeToNative } from '../../../utils/enumConversions';
+import { damlRoundingTypeToNative, damlStockClassTypeToNative } from '../../../utils/enumConversions';
 import { damlMonetaryToNative, damlTimeToDateString, normalizeNumericString } from '../../../utils/typeConversions';
 import { readSingleContract } from '../shared/singleContractRead';
 
@@ -183,34 +183,22 @@ export function damlStockClassDataToNative(
           if (raw && typeof raw === 'object' && 'tag' in raw && raw.tag === 'Some' && 'value' in raw) {
             return damlMonetaryToNative((raw as { value: Fairmint.OpenCapTable.Types.Monetary.OcfMonetary }).value);
           }
+          if (raw && typeof raw === 'object' && 'amount' in raw && 'currency' in raw) {
+            return damlMonetaryToNative(raw as Fairmint.OpenCapTable.Types.Monetary.OcfMonetary);
+          }
           return undefined;
         };
 
         const conversionPrice = extractOptionalMonetary(rec.conversion_price);
-
-        // Extract rounding_type from DAML Optional(OcfRoundingType)
-        const extractRoundingType = (raw: unknown): 'CEILING' | 'FLOOR' | 'NORMAL' => {
-          if (!raw || typeof raw !== 'object') return 'NORMAL';
-          const tag =
-            'tag' in (raw as Record<string, unknown>)
-              ? (raw as { tag: string }).tag
-              : 'value' in (raw as Record<string, unknown>)
-                ? (raw as { value: unknown } as Record<string, unknown>).tag
-                : null;
-          if (tag === 'OcfRoundingCeiling') return 'CEILING';
-          if (tag === 'OcfRoundingFloor') return 'FLOOR';
-          if (tag === 'OcfRoundingNormal') return 'NORMAL';
-          return 'NORMAL';
-        };
-        const roundingType = extractRoundingType(rec.rounding_type);
+        const roundingType = damlRoundingTypeToNative(rec.rounding_type);
 
         // Build OCF RatioConversionMechanism (required: type, ratio, conversion_price, rounding_type)
         // StockClassConversionRight schema only allows RatioConversionMechanism; additionalProperties: false
         const mechanismObj: ConversionMechanismObject = {
           type: mechanismType,
-          ratio: ratio ?? { numerator: '1', denominator: '1' },
-          conversion_price: conversionPrice ?? { amount: '0', currency: 'USD' },
-          rounding_type: roundingType,
+          ...(ratio ? { ratio } : {}),
+          ...(conversionPrice ? { conversion_price: conversionPrice } : {}),
+          ...(roundingType ? { rounding_type: roundingType } : {}),
         };
 
         // OCF StockClassConversionRight schema allows ONLY: type, conversion_mechanism,

--- a/src/functions/OpenCapTable/stockClass/stockClassDataToDaml.ts
+++ b/src/functions/OpenCapTable/stockClass/stockClassDataToDaml.ts
@@ -6,7 +6,7 @@ import type {
   StockClassConversionRight,
 } from '../../../types';
 import { validateStockClassData } from '../../../utils/entityValidators';
-import { stockClassTypeToDaml } from '../../../utils/enumConversions';
+import { roundingTypeToDaml, stockClassTypeToDaml } from '../../../utils/enumConversions';
 import {
   cleanComments,
   dateStringToDAMLTime,
@@ -69,13 +69,15 @@ function conversionMechanismToDaml(
 function extractMechanismDetails(mechanism: ConversionMechanism | ConversionMechanismObject): {
   ratio: { numerator: string; denominator: string } | null;
   conversion_price: { amount: string; currency: string } | null;
+  rounding_type: ConversionMechanismObject['rounding_type'] | null;
 } {
   if (typeof mechanism === 'string') {
-    return { ratio: null, conversion_price: null };
+    return { ratio: null, conversion_price: null, rounding_type: null };
   }
   return {
     ratio: mechanism.ratio ?? null,
     conversion_price: mechanism.conversion_price ?? null,
+    rounding_type: mechanism.rounding_type ?? null,
   };
 }
 
@@ -195,6 +197,7 @@ export function stockClassDataToDaml(stockClassData: OcfStockClass): Record<stri
             ? normalizeNumericString(right.percent_of_capitalization)
             : null,
         conversion_price: conversionPrice ? monetaryToDaml(conversionPrice) : null,
+        rounding_type: mechDetails.rounding_type ? roundingTypeToDaml(mechDetails.rounding_type) : null,
         reference_share_price: right.reference_share_price ? monetaryToDaml(right.reference_share_price) : null,
 
         reference_valuation_price_per_share: right.reference_valuation_price_per_share
@@ -207,7 +210,7 @@ export function stockClassDataToDaml(stockClassData: OcfStockClass): Record<stri
         converts_to_future_round:
           typeof right.converts_to_future_round === 'boolean' ? right.converts_to_future_round : null,
         custom_description: optionalString(right.custom_description),
-        expires_at: right.expires_at ? dateStringToDAMLTime(right.expires_at) : null,
+        expires_at: null,
       };
     }),
     liquidation_preference_multiple:

--- a/src/functions/OpenCapTable/stockClass/stockClassDataToDaml.ts
+++ b/src/functions/OpenCapTable/stockClass/stockClassDataToDaml.ts
@@ -185,6 +185,7 @@ export function stockClassDataToDaml(stockClassData: OcfStockClass): Record<stri
       }
 
       const conversionPrice = right.conversion_price ?? mechDetails.conversion_price;
+      const roundingType = right.rounding_type ?? mechDetails.rounding_type;
 
       return {
         type_: right.type,
@@ -197,7 +198,7 @@ export function stockClassDataToDaml(stockClassData: OcfStockClass): Record<stri
             ? normalizeNumericString(right.percent_of_capitalization)
             : null,
         conversion_price: conversionPrice ? monetaryToDaml(conversionPrice) : null,
-        rounding_type: mechDetails.rounding_type ? roundingTypeToDaml(mechDetails.rounding_type) : null,
+        rounding_type: roundingType ? roundingTypeToDaml(roundingType) : null,
         reference_share_price: right.reference_share_price ? monetaryToDaml(right.reference_share_price) : null,
 
         reference_valuation_price_per_share: right.reference_valuation_price_per_share

--- a/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
+++ b/src/functions/OpenCapTable/warrantIssuance/createWarrantIssuance.ts
@@ -1,6 +1,7 @@
 import { type Fairmint } from '@fairmint/open-captable-protocol-daml-js';
 import { OcpErrorCodes, OcpParseError, OcpValidationError } from '../../../errors';
 import type { CapitalizationDefinitionRules, Monetary } from '../../../types';
+import { roundingTypeToDaml } from '../../../utils/enumConversions';
 import {
   cleanComments,
   dateStringToDAMLTime,
@@ -237,21 +238,15 @@ function warrantNestedConversionTrigger(
 function toDamlRatio(mech: StockClassRatioConversionMechanismInput): {
   ratio: Fairmint.OpenCapTable.Types.Stock.OcfRatio;
   conversion_price: Fairmint.OpenCapTable.Types.Monetary.OcfMonetary;
+  rounding_type: ReturnType<typeof roundingTypeToDaml>;
 } {
-  // OcfStockClassConversionRight (DAML) has no rounding_type field — only NORMAL round-trips.
-  if (mech.rounding_type !== 'NORMAL') {
-    throw new OcpValidationError(
-      'conversion_right.conversion_mechanism.rounding_type',
-      'Warrant STOCK_CLASS_CONVERSION_RIGHT cannot persist rounding_type in DAML (OcfStockClassConversionRight omits it); use NORMAL or omit this trigger variant',
-      { code: OcpErrorCodes.INVALID_FORMAT, receivedValue: mech.rounding_type }
-    );
-  }
   return {
     ratio: {
       numerator: normalizeNumericString(mech.ratio.numerator),
       denominator: normalizeNumericString(mech.ratio.denominator),
     },
     conversion_price: monetaryToDaml(mech.conversion_price),
+    rounding_type: roundingTypeToDaml(mech.rounding_type),
   };
 }
 
@@ -267,17 +262,20 @@ function buildWarrantStockClassConversionRight(
       { source: 'conversion_right.conversion_mechanism', code: OcpErrorCodes.UNKNOWN_ENUM_VALUE }
     );
   }
-  const { ratio, conversion_price } = toDamlRatio(details.conversion_mechanism);
+  const { ratio, conversion_price, rounding_type } = toDamlRatio(details.conversion_mechanism);
   const converts_to_future_round =
     typeof details.converts_to_future_round === 'boolean' ? details.converts_to_future_round : null;
 
-  const value: Fairmint.OpenCapTable.Types.Conversion.OcfStockClassConversionRight = {
+  const value: Fairmint.OpenCapTable.Types.Conversion.OcfStockClassConversionRight & {
+    rounding_type: ReturnType<typeof roundingTypeToDaml>;
+  } = {
     type_: 'STOCK_CLASS_CONVERSION_RIGHT',
     conversion_mechanism: 'OcfConversionMechanismRatioConversion',
     conversion_trigger: warrantNestedConversionTrigger(exerciseTrigger, details.converts_to_stock_class_id),
     converts_to_stock_class_id: details.converts_to_stock_class_id,
     ratio,
     conversion_price,
+    rounding_type,
     converts_to_future_round,
     ceiling_price_per_share: null,
     custom_description: null,

--- a/src/functions/OpenCapTable/warrantIssuance/getWarrantIssuanceAsOcf.ts
+++ b/src/functions/OpenCapTable/warrantIssuance/getWarrantIssuanceAsOcf.ts
@@ -12,6 +12,7 @@ import type {
   WarrantStockClassConversionRight,
   WarrantTriggerConversionRight,
 } from '../../../types/native';
+import { damlRoundingTypeToNative } from '../../../utils/enumConversions';
 import {
   damlMonetaryToNative,
   damlMonetaryToNativeWithValidation,
@@ -255,8 +256,14 @@ function mapStockClassWarrantRightFromDaml(value: Record<string, unknown>): Warr
     );
   }
 
-  // rounding_type is not on OcfStockClassConversionRight in DAML (generated JS type has ratio +
-  // conversion_price only for ratio mech). Match StockClass readback normalization in planSecurityAliases.
+  const rounding_type = damlRoundingTypeToNative(value.rounding_type);
+  if (!rounding_type) {
+    throw new OcpValidationError(
+      'warrantIssuance.conversion_right.rounding_type',
+      'OcfRightStockClass with ratio conversion requires rounding_type',
+      { code: OcpErrorCodes.REQUIRED_FIELD_MISSING }
+    );
+  }
   const out: WarrantStockClassConversionRight = {
     type: 'STOCK_CLASS_CONVERSION_RIGHT',
     converts_to_stock_class_id: stockClassId,
@@ -264,7 +271,7 @@ function mapStockClassWarrantRightFromDaml(value: Record<string, unknown>): Warr
       type: 'RATIO_CONVERSION',
       ratio,
       conversion_price,
-      rounding_type: 'NORMAL',
+      rounding_type,
     },
   };
   if (typeof value.converts_to_future_round === 'boolean') {

--- a/src/utils/enumConversions.ts
+++ b/src/utils/enumConversions.ts
@@ -23,11 +23,63 @@ import { OcpErrorCodes, OcpParseError } from '../errors';
 import type {
   EmailType,
   PhoneType,
+  RoundingType,
   StakeholderRelationshipType,
   StakeholderStatus,
   StakeholderType,
   StockClassType,
 } from '../types/native';
+
+export type DamlRoundingType = 'OcfRoundingNormal' | 'OcfRoundingCeiling' | 'OcfRoundingFloor';
+
+export function roundingTypeToDaml(roundingType: RoundingType): DamlRoundingType {
+  switch (roundingType) {
+    case 'NORMAL':
+      return 'OcfRoundingNormal';
+    case 'CEILING':
+      return 'OcfRoundingCeiling';
+    case 'FLOOR':
+      return 'OcfRoundingFloor';
+    default: {
+      const exhaustiveCheck: never = roundingType;
+      throw new OcpParseError(`Unknown rounding type: ${exhaustiveCheck as string}`, {
+        source: 'rounding_type',
+        code: OcpErrorCodes.UNKNOWN_ENUM_VALUE,
+      });
+    }
+  }
+}
+
+export function damlRoundingTypeToNative(raw: unknown): RoundingType | undefined {
+  if (raw === null || raw === undefined) return undefined;
+
+  let value: unknown = raw;
+  while (value !== null && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    if (record.tag === 'None') return undefined;
+    if (record.tag === 'Some') {
+      const { value: optionalValue } = record;
+      value = optionalValue;
+      continue;
+    }
+    if (typeof record.tag === 'string') value = record.tag;
+    break;
+  }
+
+  switch (value) {
+    case 'OcfRoundingNormal':
+      return 'NORMAL';
+    case 'OcfRoundingCeiling':
+      return 'CEILING';
+    case 'OcfRoundingFloor':
+      return 'FLOOR';
+    default:
+      throw new OcpParseError(`Unknown DAML rounding type: ${String(value)}`, {
+        source: 'rounding_type',
+        code: OcpErrorCodes.UNKNOWN_ENUM_VALUE,
+      });
+  }
+}
 
 // ===== Email Type Conversions =====
 

--- a/src/utils/planSecurityAliases.ts
+++ b/src/utils/planSecurityAliases.ts
@@ -774,8 +774,6 @@ export function normalizeOcfData(data: unknown): Record<string, unknown> {
 
   result = normalizeVestingTermsDefaults(result);
 
-  result = normalizeConversionMechanismRoundTrip(result);
-
   result = normalizeCapitalizationDefinitionRules(result);
 
   result = deepNormalizeNumericStrings(result);
@@ -858,54 +856,6 @@ function normalizeCapitalizationDefinitionRules(data: Record<string, unknown>): 
   const changed = normalizedTriggers.some((t, i) => t !== triggers[i]);
   if (!changed) return data;
   return { ...data, conversion_triggers: normalizedTriggers };
-}
-
-/**
- * Strip fields from conversion_mechanism objects that DAML does not store,
- * so DB-sourced and Canton-sourced data compare identically.
- *
- * The DAML StockClass contract stores conversion_mechanism as an enum string
- * with ratio and conversion_price as separate top-level optional fields.
- * Fields like rounding_type exist in the OCF schema but are not stored in
- * the DAML contract, so they cannot survive the round-trip.
- *
- * Schema-default equivalence: When conversion_rights has exactly one
- * RATIO_CONVERSION right with ratio 1:1, normalize to empty. The OCP Canton
- * SDK reader (getStockClassAsOcf) fills in { numerator: '1', denominator: '1' }
- * when DAML has no explicit ratio, while the DB omits conversion_rights for
- * 1:1 preferred stock. Both are semantically equivalent.
- */
-function normalizeConversionMechanismRoundTrip(data: Record<string, unknown>): Record<string, unknown> {
-  if (data.object_type !== 'STOCK_CLASS') return data;
-  const rights = data.conversion_rights;
-  if (!Array.isArray(rights) || rights.length === 0) return data;
-
-  const normalized = (rights as Array<Record<string, unknown>>).map((right) => {
-    const mechanism = right.conversion_mechanism;
-    if (!mechanism || typeof mechanism !== 'object' || Array.isArray(mechanism)) return right;
-
-    const mech = { ...(mechanism as Record<string, unknown>) };
-    delete mech.rounding_type;
-
-    return { ...right, conversion_mechanism: mech };
-  });
-
-  // Schema-default: single 1:1 RATIO_CONVERSION → empty (matches DB omission)
-  if (normalized.length === 1) {
-    const right = normalized[0];
-    const mech = right.conversion_mechanism as Record<string, unknown> | undefined;
-    if (mech?.type === 'RATIO_CONVERSION') {
-      const ratio = mech.ratio as { numerator?: string | number; denominator?: string | number } | undefined;
-      const num = ratio?.numerator;
-      const den = ratio?.denominator;
-      const isOneToOne = (num === '1' || num === 1) && (den === '1' || den === 1);
-      if (isOneToOne && right.converts_to_future_round !== true) {
-        return { ...data, conversion_rights: [] };
-      }
-    }
-  }
-
-  return { ...data, conversion_rights: normalized };
 }
 
 /**

--- a/test/converters/stockClassConverters.test.ts
+++ b/test/converters/stockClassConverters.test.ts
@@ -11,6 +11,8 @@
  */
 
 import { convertToDaml } from '../../src/functions/OpenCapTable/capTable/ocfToDaml';
+import { damlStockClassDataToNative } from '../../src/functions/OpenCapTable/stockClass/getStockClassAsOcf';
+import { stockClassDataToDaml } from '../../src/functions/OpenCapTable/stockClass/stockClassDataToDaml';
 import type { OcfStockClass } from '../../src/types/native';
 import { initialSharesAuthorizedToDaml } from '../../src/utils/typeConversions';
 
@@ -140,6 +142,77 @@ describe('StockClass Converters', () => {
         amount: '0.001',
         currency: 'USD',
       });
+    });
+
+    test.each([
+      ['1', '1', 'NORMAL', 'OcfRoundingNormal'],
+      ['3', '2', 'CEILING', 'OcfRoundingCeiling'],
+      ['5', '4', 'FLOOR', 'OcfRoundingFloor'],
+    ] as const)(
+      'round-trips %s:%s stock-class rights with %s rounding',
+      (numerator, denominator, roundingType, damlRoundingType) => {
+        const input: OcfStockClass = {
+          ...baseData,
+          conversion_rights: [
+            {
+              type: 'STOCK_CLASS_CONVERSION_RIGHT',
+              converts_to_stock_class_id: 'class-common',
+              conversion_mechanism: {
+                type: 'RATIO_CONVERSION',
+                ratio: { numerator, denominator },
+                conversion_price: { amount: '12.5', currency: 'USD' },
+                rounding_type: roundingType,
+              },
+            },
+          ],
+        };
+
+        const daml = stockClassDataToDaml(input);
+        const damlRight = (daml.conversion_rights as Array<Record<string, unknown>>)[0];
+        expect(damlRight).toMatchObject({
+          ratio: { numerator, denominator },
+          conversion_price: { amount: '12.5', currency: 'USD' },
+          rounding_type: damlRoundingType,
+          expires_at: null,
+        });
+
+        const output = damlStockClassDataToNative(daml as unknown as Parameters<typeof damlStockClassDataToNative>[0]);
+        expect(output.conversion_rights).toEqual([
+          {
+            type: 'STOCK_CLASS_CONVERSION_RIGHT',
+            converts_to_stock_class_id: 'class-common',
+            conversion_mechanism: {
+              type: 'RATIO_CONVERSION',
+              ratio: { numerator, denominator },
+              conversion_price: { amount: '12.5', currency: 'USD' },
+              rounding_type: roundingType,
+            },
+          },
+        ]);
+      }
+    );
+
+    test('does not invent missing stock-class conversion details on readback', () => {
+      const daml = stockClassDataToDaml({
+        ...baseData,
+        conversion_rights: [
+          {
+            type: 'STOCK_CLASS_CONVERSION_RIGHT',
+            converts_to_stock_class_id: 'class-common',
+            conversion_mechanism: {
+              type: 'RATIO_CONVERSION',
+              ratio: { numerator: '1', denominator: '1' },
+            },
+          },
+        ],
+      });
+      const damlRight = (daml.conversion_rights as Array<Record<string, unknown>>)[0];
+      delete damlRight.ratio;
+      delete damlRight.conversion_price;
+      delete damlRight.rounding_type;
+
+      const output = damlStockClassDataToNative(daml as unknown as Parameters<typeof damlStockClassDataToNative>[0]);
+      expect(output.conversion_rights?.[0].conversion_mechanism).toEqual({ type: 'RATIO_CONVERSION' });
     });
 
     test('throws error when id is missing', () => {

--- a/test/converters/stockClassConverters.test.ts
+++ b/test/converters/stockClassConverters.test.ts
@@ -192,6 +192,29 @@ describe('StockClass Converters', () => {
       }
     );
 
+    test('preserves the documented top-level rounding passthrough', () => {
+      const daml = stockClassDataToDaml({
+        ...baseData,
+        conversion_rights: [
+          {
+            type: 'STOCK_CLASS_CONVERSION_RIGHT',
+            converts_to_stock_class_id: 'class-common',
+            conversion_mechanism: 'RATIO_CONVERSION',
+            ratio_numerator: '3',
+            ratio_denominator: '2',
+            conversion_price: { amount: '12.5', currency: 'USD' },
+            rounding_type: 'FLOOR',
+          },
+        ],
+      });
+
+      expect((daml.conversion_rights as Array<Record<string, unknown>>)[0]).toMatchObject({
+        ratio: { numerator: '3', denominator: '2' },
+        conversion_price: { amount: '12.5', currency: 'USD' },
+        rounding_type: 'OcfRoundingFloor',
+      });
+    });
+
     test('does not invent missing stock-class conversion details on readback', () => {
       const daml = stockClassDataToDaml({
         ...baseData,

--- a/test/converters/warrantIssuanceConverters.test.ts
+++ b/test/converters/warrantIssuanceConverters.test.ts
@@ -154,13 +154,17 @@ describe('WarrantIssuance round-trip equivalence', () => {
     expect(ocfDeepEqual(dbData as Record<string, unknown>, cantonData)).toBe(true);
   });
 
-  test('STOCK_CLASS_CONVERSION_RIGHT rejects non-NORMAL rounding_type (not persisted in DAML)', () => {
+  test.each([
+    ['NORMAL', 'OcfRoundingNormal'],
+    ['CEILING', 'OcfRoundingCeiling'],
+    ['FLOOR', 'OcfRoundingFloor'],
+  ] as const)('STOCK_CLASS_CONVERSION_RIGHT round-trips %s rounding', (roundingType, damlRoundingType) => {
     const input = {
       ...baseWarrantIssuance,
       exercise_triggers: [
         {
           type: 'AUTOMATIC_ON_CONDITION' as const,
-          trigger_id: 'w_bad_round',
+          trigger_id: `w_round_${roundingType}`,
           trigger_condition: 'X',
           conversion_right: {
             type: 'STOCK_CLASS_CONVERSION_RIGHT' as const,
@@ -168,15 +172,20 @@ describe('WarrantIssuance round-trip equivalence', () => {
             conversion_mechanism: {
               type: 'RATIO_CONVERSION' as const,
               ratio: { numerator: '1', denominator: '1' },
-              conversion_price: { amount: '1', currency: 'USD' },
-              rounding_type: 'CEILING' as const,
+              conversion_price: { amount: '7.25', currency: 'USD' },
+              rounding_type: roundingType,
             },
           },
         },
       ],
     };
-    expect(() => warrantIssuanceDataToDaml(input)).toThrow(OcpValidationError);
-    expect(() => warrantIssuanceDataToDaml(input)).toThrow(/rounding_type/);
+
+    const daml = warrantIssuanceDataToDaml(input);
+    const value = daml.exercise_triggers[0].conversion_right.value as unknown as Record<string, unknown>;
+    expect(value.rounding_type).toBe(damlRoundingType);
+    expect(value.conversion_price).toEqual({ amount: '7.25', currency: 'USD' });
+    expect(value.expires_at).toBeNull();
+    expect(ocfDeepEqual({ ...input, object_type: 'TX_WARRANT_ISSUANCE' }, roundTrip(input))).toBe(true);
   });
 
   test('STOCK_CLASS_CONVERSION_RIGHT + RATIO_CONVERSION maps to OcfRightStockClass and round-trips', () => {
@@ -207,12 +216,14 @@ describe('WarrantIssuance round-trip equivalence', () => {
     const daml = warrantIssuanceDataToDaml(input);
     const trig = daml.exercise_triggers[0];
     expect(trig.conversion_right.tag).toBe('OcfRightStockClass');
-    const sr = trig.conversion_right.value as {
+    const sr = trig.conversion_right.value as unknown as {
       type_: string;
       converts_to_stock_class_id: string;
       conversion_mechanism: string;
       ratio: { numerator: string; denominator: string };
       conversion_price: { amount: string; currency: string };
+      rounding_type: string;
+      expires_at: null;
     };
     expect(sr.type_).toBe('STOCK_CLASS_CONVERSION_RIGHT');
     expect(sr.converts_to_stock_class_id).toBe(stockClassId);
@@ -221,6 +232,8 @@ describe('WarrantIssuance round-trip equivalence', () => {
     expect(sr.ratio.denominator).toBe('2');
     expect(sr.conversion_price.amount).toBe('10');
     expect(sr.conversion_price.currency).toBe('USD');
+    expect(sr.rounding_type).toBe('OcfRoundingNormal');
+    expect(sr.expires_at).toBeNull();
 
     const dbData = { ...input, object_type: 'TX_WARRANT_ISSUANCE' } as Record<string, unknown>;
     const cantonData = roundTrip(input);

--- a/test/utils/planSecurityAliases.test.ts
+++ b/test/utils/planSecurityAliases.test.ts
@@ -1220,8 +1220,8 @@ describe('PlanSecurity alias utilities', () => {
     });
   });
 
-  describe('stock class conversion rights 1:1 schema-default', () => {
-    it('normalizes single 1:1 RATIO_CONVERSION to empty conversion_rights', () => {
+  describe('stock class conversion rights', () => {
+    it('preserves a single 1:1 RATIO_CONVERSION and its rounding type', () => {
       const cantonStyle = {
         object_type: 'STOCK_CLASS',
         id: 'sc-preferred',
@@ -1235,13 +1235,14 @@ describe('PlanSecurity alias utilities', () => {
               type: 'RATIO_CONVERSION',
               ratio: { numerator: '1', denominator: '1' },
               conversion_price: { amount: '0', currency: 'USD' },
+              rounding_type: 'CEILING',
             },
             converts_to_stock_class_id: 'common',
           },
         ],
       } as Record<string, unknown>;
       const result = normalizeOcfData(cantonStyle);
-      expect(result.conversion_rights).toEqual([]);
+      expect(result.conversion_rights).toEqual(cantonStyle.conversion_rights);
     });
 
     it('preserves non-1:1 conversion rights', () => {


### PR DESCRIPTION
## Summary

Preserve official OCF stock-class ratio conversion rights losslessly across SDK normalization and DAML writes/readback.

- keep 1:1 and non-1:1 conversion rights instead of normalizing them away
- preserve `NORMAL`, `CEILING`, and `FLOOR`
- preserve the real conversion price instead of fabricating `0 USD`
- keep unsupported `expires_at` absent
- apply the same mapping to warrant stock-class conversion rights

## Root cause and impact

The current SDK strips `rounding_type` and treats a single 1:1 right as equivalent to no conversion right. Readback also defaults rounding and price. Read-only audits found this currently affects 11 sync-enabled dev rights across 10 portals and 8 production rights across 6 portals; three dev rights use `FLOOR`.

This can make LocalNet replay appear successful after silently dropping valid source data.

## Validation

- build passed
- focused lint passed
- 3 suites / 126 tests passed
- `git diff --check` passed

## Blocker

This PR intentionally remains draft. The generated `@fairmint/open-captable-protocol-daml-js` encoder in the pinned 0.3.13 and current npm latest 0.3.27 does not yet contain `OcfStockClassConversionRight.rounding_type` and drops the field at runtime.

[DAML PR #269](https://github.com/Fairmint/open-captable-protocol-daml/pull/269) adds that field. After its bindings are published, this PR must pin the new package and pass an end-to-end dev/production replay before becoming review-ready.

This narrow main-target slice replaces only the relevant part of the stale mega-stack in SDK PRs #420/#423/#436; it does not import their unrelated changes.
