### PR TITLE
Accept all 13 OCF stakeholder relationship types in validator

### DIFF
--- a/src/utils/entityValidators.ts
+++ b/src/utils/entityValidators.ts
@@ -14,8 +14,10 @@
  *   ```
  */
 
+import { Fairmint } from '@fairmint/open-captable-protocol-daml-js';
 import { OcpErrorCodes, OcpValidationError } from '../errors';
-import type { Address, Email, Monetary, Phone } from '../types';
+import type { Address, Email, Monetary, Phone, StakeholderRelationshipType } from '../types';
+import { damlStakeholderRelationshipToNative } from './enumConversions';
 import {
   validateEnum,
   validateOptionalArray,
@@ -52,15 +54,12 @@ const STAKEHOLDER_STATUSES = [
   'TERMINATION_INVOLUNTARY_WITH_CAUSE',
 ] as const;
 
-const STAKEHOLDER_RELATIONSHIPS = [
-  'EMPLOYEE',
-  'ADVISOR',
-  'INVESTOR',
-  'FOUNDER',
-  'BOARD_MEMBER',
-  'OFFICER',
-  'OTHER',
-] as const;
+/**
+ * Derived from the DAML enum so the accepted values always match what
+ * `stakeholderRelationshipTypeToDaml` can convert, covering all 13 OCF values.
+ */
+const STAKEHOLDER_RELATIONSHIPS: readonly StakeholderRelationshipType[] =
+  Fairmint.OpenCapTable.Types.Stakeholder.OcfStakeholderRelationshipType.keys.map(damlStakeholderRelationshipToNative);
 
 // ===== Helper Validators =====
 

--- a/test/utils/entityValidators.test.ts
+++ b/test/utils/entityValidators.test.ts
@@ -336,6 +336,51 @@ describe('Entity Validators', () => {
         validateStakeholderData({ ...validStakeholder, current_status: 'ACTIVE' }, 'stakeholder')
       ).not.toThrow();
     });
+
+    // All 13 OCF StakeholderRelationshipType values must be accepted; the whitelist previously
+    // covered only 7, rejecting valid OCF data such as CONSULTANT.
+    const allRelationships = [
+      'ADVISOR',
+      'BOARD_MEMBER',
+      'CONSULTANT',
+      'EMPLOYEE',
+      'EX_ADVISOR',
+      'EX_CONSULTANT',
+      'EX_EMPLOYEE',
+      'EXECUTIVE',
+      'FOUNDER',
+      'INVESTOR',
+      'NON_US_EMPLOYEE',
+      'OFFICER',
+      'OTHER',
+    ];
+
+    it.each(allRelationships)('passes for current_relationship %s', (relationship) => {
+      expect(() =>
+        validateStakeholderData({ ...validStakeholder, current_relationship: relationship }, 'stakeholder')
+      ).not.toThrow();
+    });
+
+    it('passes for current_relationships containing every OCF relationship', () => {
+      expect(() =>
+        validateStakeholderData({ ...validStakeholder, current_relationships: allRelationships }, 'stakeholder')
+      ).not.toThrow();
+    });
+
+    it('throws for invalid current_relationship', () => {
+      expect(() =>
+        validateStakeholderData({ ...validStakeholder, current_relationship: 'INVALID_RELATIONSHIP' }, 'stakeholder')
+      ).toThrow(OcpValidationError);
+    });
+
+    it('throws for invalid current_relationships entry', () => {
+      expect(() =>
+        validateStakeholderData(
+          { ...validStakeholder, current_relationships: ['EMPLOYEE', 'INVALID_RELATIONSHIP'] },
+          'stakeholder'
+        )
+      ).toThrow(OcpValidationError);
+    });
   });
 
   describe('validateStockClassData', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Symptom

Cap-table replication fails for portal **zazmic** (devnet) with:

```
Validation error at 'stakeholder.current_relationships[0]': Value must be one of:
EMPLOYEE, ADVISOR, INVESTOR, FOUNDER, BOARD_MEMBER, OFFICER, OTHER
```

Failing object: stakeholder `sh_6911079e1390`, whose relationship is `CONSULTANT` — a valid OCF value.

## Root cause

`STAKEHOLDER_RELATIONSHIPS` in `src/utils/entityValidators.ts` was a hardcoded list of only 7 values, while OCF `StakeholderRelationshipType` defines 13. `validateStakeholderData` runs before Daml conversion, so valid data was rejected prior to any ledger write.

Missing values: `CONSULTANT`, `EX_ADVISOR`, `EX_CONSULTANT`, `EX_EMPLOYEE`, `EXECUTIVE`, `NON_US_EMPLOYEE`.

Every other layer already supported all 13: the SDK `StakeholderRelationshipType` type, both `enumConversions` converters, and the Daml `OcfStakeholderRelationshipType` enum (`OcfRelConsultant` etc.). Only the validator whitelist was truncated.

## Fix

Derive the accepted values from the Daml enum via the existing exhaustive converter, so the validator accepts exactly what `stakeholderRelationshipTypeToDaml` can convert and the list cannot drift again. Adding a Daml constructor forces a converter update (its `default` branch is a `never` check), and the validator follows automatically.

## Enum audit

Checked every whitelist in `entityValidators.ts` against `libs/Open-Cap-Format-OCF/schema/enums`. `STAKEHOLDER_RELATIONSHIPS` was the only truncated one (7 of 13). `EMAIL_TYPES`, `PHONE_TYPES`, `ADDRESS_TYPES`, `STAKEHOLDER_TYPES`, `STOCK_CLASS_TYPES`, `STOCK_ISSUANCE_TYPES`, `VALUATION_TYPES`, and `STAKEHOLDER_STATUSES` all match their OCF schemas exactly and were left untouched.

## Tests

New regression coverage in `test/utils/entityValidators.test.ts` exercises all 13 relationship values for both `current_relationship` and `current_relationships`, plus negative cases. Restoring the old whitelist fails 7 of them with the exact production error message.

Full CI sequence passes: `lint`, `build`, `test:declarations`, `typecheck`, and `test:ci` (61 suites, 2789 tests).

## Follow-up required

Consumers stay broken until a release ships. After merge, publish `@open-captable-protocol/canton`, then bump the pin in the `canton` repo's `package.json` from `0.8.0` to the new version and re-run zazmic replication.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69e4c363-efc2-458d-8469-d0bd87cbf1e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69e4c363-efc2-458d-8469-d0bd87cbf1e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stakeholder relationship validation now supports all 13 recognized OCF relationship values.
  * Validation continues to reject unsupported relationship values for both individual and list fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->