### PR TITLE
ci: add dependabot cooldown (1 day minimum)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,8 @@ updates:
     open-pull-requests-limit: 1
     commit-message:
       prefix: 'ci'
+    cooldown:
+      default-days: 1
     groups:
       all-actions:
         patterns:


### PR DESCRIPTION
Adds a 1-day Dependabot cooldown (`cooldown.default-days: 1`) on ecosystems that were missing it.

Existing 7-day npm/bun cooldowns are preserved unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Dependabot scheduling with no runtime or application code impact.
> 
> **Overview**
> **Dependabot** for **GitHub Actions** now includes `cooldown.default-days: 1`, so Dependabot waits at least one day before opening another update PR for that ecosystem after a previous one.
> 
> The **npm** entry still uses its existing **7-day** cooldown; this PR does not change npm or other ecosystems beyond the new Actions cooldown block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa257f5cda182e9965c805341e233c79fbed23b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->