### PR TITLE
Point README and CLAUDE at the ocp-canton-sdk docs hub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,19 @@
 # ocp-canton-sdk
 
-## Step 0: Read the public wiki
+## Step 0: Read the canonical docs
 
-Start with the [wiki Home](https://github.com/Fairmint/ocp-canton-sdk/wiki),
-[Contributing](https://github.com/Fairmint/ocp-canton-sdk/wiki/Contributing), and the relevant
-[ADRs](https://github.com/Fairmint/ocp-canton-sdk/wiki/ADRs). Use [`src/index.ts`](src/index.ts),
-declaration tests, the pinned OCF schemas, current source, and integration tests as the source of
-truth for exact behavior. Before handing off a change, run the relevant checks in `README.md` and
+Read the Fairmint developer documentation before making architectural or operational changes:
+
+- [OCP Canton SDK](https://github.com/Fairmint/dev-docs/blob/main/docs/onchain/ocp/canton-sdk.md)
+- [OCP developer map](https://github.com/Fairmint/dev-docs/blob/main/docs/onchain/ocp/README.md)
+- [Update lifecycle](https://github.com/Fairmint/dev-docs/blob/main/docs/onchain/ocp/update-lifecycle.md)
+- [ADR-009: Batch cap-table updates](https://github.com/Fairmint/dev-docs/blob/main/adrs/ADR-009-Batch-Cap-Table-Updates.md)
+- [ADR-010: OCF entity metadata registry](https://github.com/Fairmint/dev-docs/blob/main/adrs/ADR-010-OCF-Entity-Metadata-Registry.md)
+- [Canton SDK landscape](https://github.com/Fairmint/dev-docs/blob/main/docs/onchain/canton/sdk-landscape.md)
+
+Then inspect [`src/index.ts`](src/index.ts), declaration tests, the pinned OCF schemas, current
+source, and integration tests as the source of truth for exact behavior. The dev docs are a map, not
+a substitute for the source.
+
+Before handing off a change, run the relevant checks in [`README.md`](README.md) and
 [`package.json`](package.json).

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 High-level TypeScript SDK for Open Cap Table Protocol contracts on Canton Network.
 
-## Developer documentation
+## Documentation
 
-The public [GitHub wiki](https://github.com/Fairmint/ocp-canton-sdk/wiki) is the canonical guide for
-getting started, cap-table operations, architecture, environments, observability, and accepted
-decisions. [`src/index.ts`](src/index.ts) defines the supported package boundary; use current
-source, declaration tests, and integration tests for exact types and behavior.
+- [OCP Canton SDK](https://github.com/Fairmint/dev-docs/blob/main/docs/onchain/ocp/canton-sdk.md)
+- [OCP developer map](https://github.com/Fairmint/dev-docs/blob/main/docs/onchain/ocp/README.md)
+- [Update lifecycle](https://github.com/Fairmint/dev-docs/blob/main/docs/onchain/ocp/update-lifecycle.md)
+- [ADR-009: Batch cap-table updates](https://github.com/Fairmint/dev-docs/blob/main/adrs/ADR-009-Batch-Cap-Table-Updates.md)
+- [ADR-010: OCF entity metadata registry](https://github.com/Fairmint/dev-docs/blob/main/adrs/ADR-010-OCF-Entity-Metadata-Registry.md)
+- [Canton SDK landscape](https://github.com/Fairmint/dev-docs/blob/main/docs/onchain/canton/sdk-landscape.md)
+
+[`src/index.ts`](src/index.ts) defines the supported package boundary; use current source,
+declaration tests, and integration tests for exact types and behavior.
 
 ## Install
 

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -25,5 +25,5 @@ npm run typecheck
 npm run test:declarations
 ```
 
-See the public [architecture guide](https://github.com/Fairmint/ocp-canton-sdk/wiki/Architecture)
+See the public [architecture guide](https://github.com/Fairmint/dev-docs/blob/main/docs/onchain/ocp/architecture.md)
 for source-of-truth boundaries.

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -25,5 +25,6 @@ npm run typecheck
 npm run test:declarations
 ```
 
-See the public [architecture guide](https://github.com/Fairmint/dev-docs/blob/main/docs/onchain/ocp/architecture.md)
+See the public
+[architecture guide](https://github.com/Fairmint/dev-docs/blob/main/docs/onchain/ocp/architecture.md)
 for source-of-truth boundaries.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to [dev-docs #45](https://github.com/Fairmint/dev-docs/pull/45). Source-repo pointers only — **wiki untouched**.

- README and CLAUDE Step 0 now point at the OCP canton-sdk hub, update lifecycle, architecture, sdk-landscape, and ADR-009/010
- `src/index.ts` stays the SDK surface source of truth
- Install and repo checks unchanged

Wiki Home redirect comes after this lands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd07f441-0840-4d36-b89c-c08846bb6aba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd07f441-0840-4d36-b89c-c08846bb6aba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to reference the canonical Fairmint developer documentation.
  * Added links to SDK documentation, developer maps, lifecycle guidance, ADRs, and the Canton SDK landscape.
  * Updated architecture documentation links to replace deprecated references.
  * Retained guidance on supported packages, authoritative source code, and required testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->