### PR TITLE
Point OcpClient JSDoc at public wiki; drop internal package refs

### DIFF
--- a/src/OcpClient.ts
+++ b/src/OcpClient.ts
@@ -7,8 +7,7 @@
  *
  * Payment-stream, coupon-minter, and related validator-backed helpers were removed in v0.4.0. Consumers that need those flows must implement them against the injected ledger and validator clients (or other integration of their choice).
  *
- * **Company valuation reports** (`OpenCapTableReports` DAML) are not part of this package — use
- * `@fairmint/canton-fairmint-sdk` (`createFairmintOcpClient`) and `@fairmint/daml-js` instead (v0.5.0+).
+ * **Company valuation reports** (`OpenCapTableReports`) are not part of this package (removed from the public client in v0.5.0+).
  *
  * @example
  * ```typescript
@@ -51,7 +50,7 @@
  * });
  * ```
  *
- * @see https://ocp.canton.fairmint.com/ — documentation site (fairmint/web)
+ * @see https://github.com/Fairmint/ocp-canton-sdk/wiki
  *
  * @module
  */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `OcpClient` module JSDoc for public consumers:

- `@see` now points at the public wiki instead of `ocp.canton.fairmint.com` / `fairmint/web`
- Company valuation reports (`OpenCapTableReports`) are described as out of this package (v0.5.0+), without naming Fairmint-internal packages

No runtime changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd07f441-0840-4d36-b89c-c08846bb6aba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd07f441-0840-4d36-b89c-c08846bb6aba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that OpenCapTableReports is not included in the package.
  * Updated the documentation link to the OCP Canton SDK wiki.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->