### PR TITLE
Bump @fairmint/canton-node-sdk to 0.0.259

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@apidevtools/json-schema-ref-parser": "15.5.1",
     "@eslint/eslintrc": "3.3.6",
     "@fairmint/canton-dev-tools": "0.1.7",
-    "@fairmint/canton-node-sdk": "0.0.250",
+    "@fairmint/canton-node-sdk": "0.0.259",
     "@fairmint/open-captable-protocol-daml-js": "0.3.33",
     "@types/jest": "30.0.0",
     "@types/node": "25.6.0",


### PR DESCRIPTION
Inherits unified 60s read retries from canton-node-sdk #409.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bump with no code changes; behavior change is limited to Canton read retry timing in consumers of the updated SDK.
> 
> **Overview**
> Bumps the **`@fairmint/canton-node-sdk`** dev dependency from **0.0.250** to **0.0.259** so local development and CI exercise the newer SDK release.
> 
> That version pulls in **unified 60-second read retries** from upstream canton-node-sdk (#409). There are **no application source changes** in this repo; **`peerDependencies`** for the SDK are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c336f7d4bf56947772d35de449db97f5428424a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Canton Node SDK development dependency to version 0.0.259.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->